### PR TITLE
Parser rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/*
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\Yannick\\AppData\\Local\\Programs\\Python\\Python36\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\Yannick\\AppData\\Local\\Programs\\Python\\Python36\\python.exe"
-}

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -75,16 +75,13 @@ class ButtonOptionsDialog(QDialog):
             self.main.comms.serialWrite("local_btnmask="+str(mask)+"\n")
 
         elif(self.id == 1):
-            cmd = "spibtn_mode="+str(self.modeBox.currentData()+";")
-            cmd += "spi_btnnum="+str(self.numBtnBox.value())+";"
-            cmd += "spi_btnpol="+("1" if self.polBox.isChecked() else "0")+";"
+            self.main.comms.serialWrite("spibtn_mode="+str(self.modeBox.currentData()))
+            self.main.comms.serialWrite("spi_btnnum="+str(self.numBtnBox.value()))
+            self.main.comms.serialWrite("spi_btnpol="+("1" if self.polBox.isChecked() else "0"))
     
-            self.main.comms.serialWrite(cmd)
-
+    
         elif(self.id == 2):
-            cmd = "shifter_mode="+str(self.modeBox.currentData())
-            self.main.comms.serialWrite(cmd)
-        
+            self.main.comms.serialWrite("shifter_mode="+str(self.modeBox.currentData()))
         self.close()
 
     def showEvent(self,event):
@@ -96,26 +93,32 @@ class ButtonOptionsDialog(QDialog):
 
     def readValues(self):
         if(self.id == 0): # Local
-            mask = int(self.main.comms.serialGet("local_btnmask\n"))
-            for i in range(8):
-                self.buttongroup.button(i).setChecked(mask & (1 << i))
-
+            def localcb(mask):
+                for i in range(8):
+                    self.buttongroup.button(i).setChecked(mask & (1 << i))
+            self.main.comms.serialGetAsync("local_btnmask",localcb,int)
+            
+        # SPI
         elif(self.id == 1):
-            self.numBtnBox.setValue(int(self.main.comms.serialGet("spi_btnnum?\n")))
-
+            self.main.comms.serialGetAsync("spi_btnnum?",self.numBtnBox.setValue,int)
             self.modeBox.clear()
-            modes = self.main.comms.serialGet("spibtn_mode!\n").split("\n")
-            modes = [m.split(":") for m in modes]
-            for m in modes:
-                self.modeBox.addItem(m[0],m[1])
-            self.modeBox.setCurrentIndex(int(self.main.comms.serialGet("spibtn_mode?\n")))
-
-            self.polBox.setChecked(int(self.main.comms.serialGet("spi_btnpol?\n")))
-        
+            def modecb(mode):
+                modes = mode.split("\n")
+                modes = [m.split(":") for m in modes if m]
+                for m in modes:
+                    self.modeBox.addItem(m[0],m[1])
+                self.main.comms.serialGetAsync("spibtn_mode?",self.modeBox.setCurrentIndex,int)
+            self.main.comms.serialGetAsync("spibtn_mode!",modecb)
+            self.main.comms.serialGetAsync("spi_btnpol?",self.polBox.setChecked,int)
+           
+            
+        # Shifter
         elif(self.id == 2):
             self.modeBox.clear()
-            modes = self.main.comms.serialGet("shifter_mode!\n").split("\n")
-            modes = [m.split(":") for m in modes]
-            for m in modes:
-                self.modeBox.addItem(m[0],m[1])
-            self.modeBox.setCurrentIndex(int(self.main.comms.serialGet("shifter_mode?\n")))
+            def modecb(mode):
+                modes = mode.split("\n")
+                modes = [m.split(":") for m in modes if m]
+                for m in modes:
+                    self.modeBox.addItem(m[0],m[1])
+                self.main.comms.serialGetAsync("shifter_mode?",self.modeBox.setCurrentIndex,int)
+            self.main.comms.serialGetAsync("shifter_mode!",modecb)

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -72,18 +72,18 @@ class ButtonOptionsDialog(QDialog):
             for i in range(8):
                 if(self.buttongroup.button(i).isChecked()):
                     mask |= 1 << i
-            self.main.serialWrite("local_btnmask="+str(mask)+"\n")
+            self.main.comms.serialWrite("local_btnmask="+str(mask)+"\n")
 
         elif(self.id == 1):
             cmd = "spibtn_mode="+str(self.modeBox.currentData()+";")
             cmd += "spi_btnnum="+str(self.numBtnBox.value())+";"
             cmd += "spi_btnpol="+("1" if self.polBox.isChecked() else "0")+";"
     
-            self.main.serialWrite(cmd)
+            self.main.comms.serialWrite(cmd)
 
         elif(self.id == 2):
             cmd = "shifter_mode="+str(self.modeBox.currentData())
-            self.main.serialWrite(cmd)
+            self.main.comms.serialWrite(cmd)
         
         self.close()
 
@@ -96,26 +96,26 @@ class ButtonOptionsDialog(QDialog):
 
     def readValues(self):
         if(self.id == 0): # Local
-            mask = int(self.main.serialGet("local_btnmask\n"))
+            mask = int(self.main.comms.serialGet("local_btnmask\n"))
             for i in range(8):
                 self.buttongroup.button(i).setChecked(mask & (1 << i))
 
         elif(self.id == 1):
-            self.numBtnBox.setValue(int(self.main.serialGet("spi_btnnum?\n")))
+            self.numBtnBox.setValue(int(self.main.comms.serialGet("spi_btnnum?\n")))
 
             self.modeBox.clear()
-            modes = self.main.serialGet("spibtn_mode!\n").split("\n")
+            modes = self.main.comms.serialGet("spibtn_mode!\n").split("\n")
             modes = [m.split(":") for m in modes]
             for m in modes:
                 self.modeBox.addItem(m[0],m[1])
-            self.modeBox.setCurrentIndex(int(self.main.serialGet("spibtn_mode?\n")))
+            self.modeBox.setCurrentIndex(int(self.main.comms.serialGet("spibtn_mode?\n")))
 
-            self.polBox.setChecked(int(self.main.serialGet("spi_btnpol?\n")))
+            self.polBox.setChecked(int(self.main.comms.serialGet("spi_btnpol?\n")))
         
         elif(self.id == 2):
             self.modeBox.clear()
-            modes = self.main.serialGet("shifter_mode!\n").split("\n")
+            modes = self.main.comms.serialGet("shifter_mode!\n").split("\n")
             modes = [m.split(":") for m in modes]
             for m in modes:
                 self.modeBox.addItem(m[0],m[1])
-            self.modeBox.setCurrentIndex(int(self.main.serialGet("shifter_mode?\n")))
+            self.modeBox.setCurrentIndex(int(self.main.comms.serialGet("shifter_mode?\n")))

--- a/ffb_ui.py
+++ b/ffb_ui.py
@@ -114,7 +114,7 @@ class FfbUI(WidgetUI):
         try:
             def f(d):
                 rate,active = d
-                act = ("FFB ON" if active == "1" else "FFB OFF")
+                act = ("FFB ON" if active else "FFB OFF")
                 self.label_HIDrate.setText(str(rate)+"Hz" + " (" + act + ")")
             self.main.comms.serialGetAsync(["hidrate","ffbactive"],f,int)
         except:

--- a/ffb_ui.py
+++ b/ffb_ui.py
@@ -111,8 +111,6 @@ class FfbUI(WidgetUI):
         self.main.comms.serialGetAsync("invertx?",self.checkBox_invertX.setChecked,int)
 
     def updateTimer(self):
-        if self.main.serialBusy:
-            return
         try:
             def f(d):
                 rate,active = d

--- a/main.py
+++ b/main.py
@@ -189,7 +189,7 @@ class MainUi(QMainWindow):
         min_fw_t = [int(i) for i in min_fw.split(".")]
         self.log("FW v" + self.fwverstr)
         fwoutdated = False
-        guioutdated = fwver[0] > min_fw_t[0]
+        guioutdated = fwver[0] > min_fw_t[0] or fwver[1] > min_fw_t[1]
 
         for v in itertools.zip_longest(min_fw_t,fwver,fillvalue=0):
             if(v[0] < v[1]): # Newer

--- a/midi_ui.py
+++ b/midi_ui.py
@@ -1,0 +1,17 @@
+from PyQt5.QtWidgets import QWidget
+from helper import res_path
+from PyQt5 import uic
+import main
+from base_ui import WidgetUI
+class MidiUI(WidgetUI):
+    def __init__(self, main=None):
+        WidgetUI.__init__(self, main,'midi.ui')
+        
+        self.initUi()
+        self.horizontalSlider_power.valueChanged.connect(lambda val : self.main.comms.serialWrite("power="+str(val)))
+        self.horizontalSlider_amp.valueChanged.connect(lambda val : self.main.comms.serialWrite("range="+str(val)))
+        
+
+    def initUi(self):
+        self.main.comms.serialGetAsync("power?",self.horizontalSlider_power.setValue,int)
+        self.main.comms.serialGetAsync("range?",self.horizontalSlider_amp.setValue,int)

--- a/pwmdriver_ui.py
+++ b/pwmdriver_ui.py
@@ -18,25 +18,27 @@ class PwmDriverUI(WidgetUI):
         self.pushButton_apply.clicked.connect(self.apply)
 
     def initUi(self):
-        self.comboBox_mode.clear()
-        modes = self.main.comms.serialGet("pwm_mode!\n").split("\n")
-        modes = [m.split(":") for m in modes]
-        for m in modes:
-            self.comboBox_mode.addItem(m[0],m[1])
-        self.comboBox_mode.setCurrentIndex(int(self.main.comms.serialGet("pwm_mode?\n")))
-
+        self.main.comms.serialGetAsync("pwm_mode!",self.pwmmode_cb)
+        self.main.comms.serialGetAsync("pwm_speed!",self.freq_cb)
+    
+    def freq_cb(self,modes):
         self.comboBox_freq.clear()
-        modes = self.main.comms.serialGet("pwm_speed!\n").split("\n")
-        modes = [m.split(":") for m in modes]
+        modes = [m.split(":") for m in modes.split("\n") if m]
         for m in modes:
             self.comboBox_freq.addItem(m[0],m[1])
-        self.comboBox_freq.setCurrentIndex(int(self.main.comms.serialGet("pwm_speed?\n")))
+        self.main.comms.serialGetAsync("pwm_speed?",self.comboBox_freq.setCurrentIndex,int)
+
+    def pwmmode_cb(self,modes):
+        self.comboBox_mode.clear()
+        modes = [m.split(":") for m in modes.split("\n") if m]
+        for m in modes:
+            self.comboBox_mode.addItem(m[0],m[1])
+        self.main.comms.serialGetAsync("pwm_mode?",self.comboBox_mode.setCurrentIndex,int)
 
  
     def apply(self):
-        cmd = "pwm_mode="+str(self.comboBox_mode.currentData())+";"
-        cmd+= "pwm_speed="+str(self.comboBox_freq.currentData())+";"
 
-        self.main.comms.serialWrite(cmd)
+        self.main.comms.serialWrite("pwm_mode="+str(self.comboBox_mode.currentData()))
+        self.main.comms.serialWrite("pwm_speed="+str(self.comboBox_freq.currentData()))
         self.initUi() # Update UI
 

--- a/pwmdriver_ui.py
+++ b/pwmdriver_ui.py
@@ -19,24 +19,24 @@ class PwmDriverUI(WidgetUI):
 
     def initUi(self):
         self.comboBox_mode.clear()
-        modes = self.main.serialGet("pwm_mode!\n").split("\n")
+        modes = self.main.comms.serialGet("pwm_mode!\n").split("\n")
         modes = [m.split(":") for m in modes]
         for m in modes:
             self.comboBox_mode.addItem(m[0],m[1])
-        self.comboBox_mode.setCurrentIndex(int(self.main.serialGet("pwm_mode?\n")))
+        self.comboBox_mode.setCurrentIndex(int(self.main.comms.serialGet("pwm_mode?\n")))
 
         self.comboBox_freq.clear()
-        modes = self.main.serialGet("pwm_speed!\n").split("\n")
+        modes = self.main.comms.serialGet("pwm_speed!\n").split("\n")
         modes = [m.split(":") for m in modes]
         for m in modes:
             self.comboBox_freq.addItem(m[0],m[1])
-        self.comboBox_freq.setCurrentIndex(int(self.main.serialGet("pwm_speed?\n")))
+        self.comboBox_freq.setCurrentIndex(int(self.main.comms.serialGet("pwm_speed?\n")))
 
  
     def apply(self):
         cmd = "pwm_mode="+str(self.comboBox_mode.currentData())+";"
         cmd+= "pwm_speed="+str(self.comboBox_freq.currentData())+";"
 
-        self.main.serialWrite(cmd)
+        self.main.comms.serialWrite(cmd)
         self.initUi() # Update UI
 

--- a/res/ffbclass.ui
+++ b/res/ffbclass.ui
@@ -89,7 +89,10 @@
             <number>255</number>
            </property>
            <property name="value">
-            <number>200</number>
+            <number>102</number>
+           </property>
+           <property name="sliderPosition">
+            <number>102</number>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -105,7 +108,7 @@
             <number>1080</number>
            </property>
            <property name="sliderPosition">
-            <number>900</number>
+            <number>5</number>
            </property>
            <property name="tracking">
             <bool>true</bool>
@@ -191,7 +194,10 @@
             <number>255</number>
            </property>
            <property name="value">
-            <number>127</number>
+            <number>0</number>
+           </property>
+           <property name="sliderPosition">
+            <number>0</number>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -217,7 +223,10 @@
             <number>255</number>
            </property>
            <property name="value">
-            <number>127</number>
+            <number>0</number>
+           </property>
+           <property name="sliderPosition">
+            <number>0</number>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/res/midi.ui
+++ b/res/midi.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Midi</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Strength</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSlider" name="horizontalSlider_power">
+        <property name="maximum">
+         <number>20000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_power">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="horizontalSlider_amp">
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Amplitude</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_amp">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Info</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_info">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This only works with the TMC4671. &lt;/p&gt;&lt;p&gt;Set it up first and make sure it initialized.&lt;/p&gt;&lt;p&gt;When a note is played on the first channel it will strongly hold the motor&lt;/p&gt;&lt;p&gt;and modulate the electrical angle in a sine wave.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>horizontalSlider_power</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>label_power</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>173</x>
+     <y>155</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>357</x>
+     <y>155</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>horizontalSlider_amp</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>label_amp</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>199</x>
+     <y>202</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>357</x>
+     <y>202</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/res/tmc4671_ui.ui
+++ b/res/tmc4671_ui.ui
@@ -20,6 +20,100 @@
       <string>TMC4671</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="3" alignment="Qt::AlignTop">
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>225</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>PIDs</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Torque P</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="spinBox_tp">
+           <property name="maximum">
+            <number>32767</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Torque I</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="spinBox_ti">
+           <property name="maximum">
+            <number>32767</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Flux P</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="spinBox_fp">
+           <property name="maximum">
+            <number>32767</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Flux I</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QSpinBox" name="spinBox_fi">
+           <property name="maximum">
+            <number>32767</number>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QPushButton" name="pushButton_submitpid">
+           <property name="text">
+            <string>Change pids</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="checkBox_advancedpid">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toggles between parallel and sequential PI modes. Requires retuning.&lt;br/&gt;Advanced (sequential) can improve impulse response.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Advanced mode</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2" alignment="Qt::AlignTop">
        <widget class="QGroupBox" name="groupBox_3">
         <property name="sizePolicy">
@@ -123,101 +217,20 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="3" alignment="Qt::AlignTop">
-       <widget class="QGroupBox" name="groupBox_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="8" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
-        <property name="maximumSize">
+        <property name="sizeHint" stdset="0">
          <size>
-          <width>225</width>
-          <height>16777215</height>
+          <width>20</width>
+          <height>40</height>
          </size>
         </property>
-        <property name="title">
-         <string>PIDs</string>
-        </property>
-        <layout class="QFormLayout" name="formLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Torque P</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="spinBox_tp">
-           <property name="maximum">
-            <number>32767</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Torque I</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="spinBox_ti">
-           <property name="maximum">
-            <number>32767</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Flux P</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="spinBox_fp">
-           <property name="maximum">
-            <number>32767</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Flux I</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QSpinBox" name="spinBox_fi">
-           <property name="maximum">
-            <number>32767</number>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QPushButton" name="pushButton_submitpid">
-           <property name="text">
-            <string>Change pids</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="checkBox_advancedpid">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toggles between parallel and sequential PI modes. Requires retuning.&lt;br/&gt;Advanced (sequential) can improve impulse response.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Advanced mode</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+       </spacer>
       </item>
-      <item row="3" column="0">
+      <item row="3" column="0" rowspan="3">
        <widget class="QGroupBox" name="groupBox_4">
         <property name="title">
          <string>More</string>
@@ -282,18 +295,21 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+      <item row="9" column="0" colspan="4">
+       <widget class="QProgressBar" name="progressBar_power">
+        <property name="maximum">
+         <number>28000</number>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+        <property name="value">
+         <number>0</number>
         </property>
-       </spacer>
+        <property name="textVisible">
+         <bool>true</bool>
+        </property>
+        <property name="format">
+         <string>%p% Power</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -58,6 +58,9 @@ class SerialComms(QObject):
 
         data = self.serial.readAll()
         text = data.data().decode("utf-8")
+        if(len(self.serialQueue) == 0 or text[0]!=">"):
+            self.main.serialchooser.serialLog(text)
+            return
 
         ################################
         def process_cmd(reply,cur_queue): 
@@ -92,6 +95,7 @@ class SerialComms(QObject):
         split_reply = text.split(">")
         n = 0
         self.cmdbuf = []
+        
         cur_queue = self.serialQueue[0]
         for reply in split_reply:
             if reply=="":

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -1,0 +1,146 @@
+import queue
+
+
+class SerialComms:
+    def __init__(self,main,serialport):
+        self.serial = serialport
+        self.main=main
+        self.serialQueue = queue.Queue()
+        self.sendQueue = queue.Queue()
+        self.serial.readyRead.connect(self.serialReceive)
+        self.sentCommandSize=0 # tracks sent bytes so never more than 64 bytes are sent
+
+    def checkOk(self,reply):
+        if(reply == "OK" or reply.find("Err") == -1):
+            return
+        else:
+            self.main.log(reply)
+
+    def serialWrite(self,cmd):
+        if(self.serial.isOpen()):
+            self.serialGetAsync(cmd,self.checkOk,readall=True)
+            if(not self.serial.waitForBytesWritten(1000)):
+                self.main.log("Error writing "+cmd)
+
+    def setAsync(self,enabled):
+        try:
+            if(enabled):
+                self.serial.readyRead.connect(self.serialReceive)
+            else:
+                self.serial.readyRead.disconnect(self.serialReceive)
+        except:
+            pass
+
+    def checkSendQueue(self):
+        if(not self.sendQueue.empty()): # remaining commands
+            cmd = self.sendQueue.get()
+            if(self.sentCommandSize + len(cmd) < 64):
+                print("Removing queue")
+                self.sentCommandSize += len(cmd)
+                self.main.serialchooser.write(bytes(cmd,"utf-8"))
+            else:
+                # Add to send queue again
+                self.sendQueue.put(cmd)
+
+    def serialReceive(self):
+        data = self.serial.readAll()
+        text = data.data().decode("utf-8")
+
+        # Command replies start with > and end with \n
+        if(self.serialQueue.empty()):
+            self.main.serialchooser.serialLog(text)
+            self.checkSendQueue()
+            return
+        cur_queue = self.serialQueue.get()
+        self.sentCommandSize -= len(cur_queue[0])
+        
+        def process_cmd(reply,cur_queue): 
+            if(reply[0] == ">"):
+                if(not cur_queue[3]):
+                    reply = reply[1::]
+                
+                if(reply.startswith("Err")):
+                    self.main.log(reply)
+                elif(cur_queue[1]):
+                    if(cur_queue[2]):
+                        reply = cur_queue[2](reply) #apply conversion
+                    cur_queue[1](reply)
+                
+            else:
+                # Not a command. pass to log
+                self.main.serialchooser.serialLog(reply+"\n")
+            self.checkSendQueue()
+
+        if(cur_queue[3]): # read all
+            process_cmd(text,cur_queue)
+            return
+        for reply in text.split("\n"):
+            if reply=="":
+                continue
+            
+            process_cmd(reply,cur_queue)
+            if(not self.serialQueue.empty()):
+                cur_queue = self.serialQueue.get()
+                self.sentCommandSize -= len(cur_queue[0])
+        
+    """
+     Get asynchronous commands and pass the result to the callback. 
+     Better performance.
+     cmds and callbacks can be lists or a single command (without ; or \n)
+     Pass a conversion function to apply to all replies before passing to callbacks. (int or float for example)
+    """
+    def serialGetAsync(self,cmds,callbacks,convert=None,readall=False):
+        commands=[]
+        if(type(cmds) == list and type(callbacks) == list):
+            for cmd,callback in zip(cmds,callbacks):
+                cmd = cmd+";"
+                self.serialQueue.put([cmd,callback,convert,False])
+                commands.append(cmd)
+        elif(type(cmds) == list):
+            for cmd in cmds:
+                cmd = cmd+";"
+                self.serialQueue.put([cmd,callbacks,convert,readall])
+                commands.append(cmd)
+        else:
+            cmds = cmds+";"
+            self.serialQueue.put([cmds,callbacks,convert,readall])
+            commands.append(cmds)
+
+        for cmd in commands:
+            
+            if(self.sentCommandSize + len(cmd) < 64):
+                self.sentCommandSize+=len(cmd)
+                self.main.serialchooser.write(bytes(cmd,"utf-8"))
+            else:
+                # Add to send queue
+                print("Append queue")
+                self.sendQueue.put(cmd)
+
+
+
+    # get a synchronous reply with timeout
+    def serialGet(self,cmd,timeout=500):
+    
+        if(not self.serial.isOpen()):
+            self.main.log("Error: Serial closed")
+            return None
+    
+        self.setAsync(False)
+        self.main.serialchooser.write(bytes(cmd,"utf-8"))
+
+        if(not self.serial.waitForReadyRead(timeout)):
+            self.main.log("Error: Serial timeout")
+            self.setAsync(True)
+            return None
+        
+        data = self.serial.readAll()
+        self.setAsync(True)
+        lastSerial = data.data().decode("utf-8")
+        #print(lastSerial)
+
+        lastSerial=lastSerial.replace(">","")
+        
+        if(lastSerial and lastSerial[-1] == "\n"):
+            lastSerial=lastSerial[0:-1]
+        
+        return lastSerial

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -9,7 +9,7 @@ class SerialComms:
         self.sendQueue = queue.Queue()
         self.serial.readyRead.connect(self.serialReceive)
         self.sentCommandSize=0 # tracks sent bytes so never more than 64 bytes are sent
-
+        self.waitForEmptyQueue = False
     def checkOk(self,reply):
         if(reply == "OK" or reply.find("Err") == -1):
             return
@@ -74,7 +74,7 @@ class SerialComms:
         if(cur_queue[3]): # read all
             process_cmd(text,cur_queue)
             return
-        for reply in text.split("\n"):
+        for reply in text.split(">"):
             if reply=="":
                 continue
             
@@ -124,7 +124,9 @@ class SerialComms:
         if(not self.serial.isOpen()):
             self.main.log("Error: Serial closed")
             return None
-    
+        if not self.serialQueue.empty():
+            # do something to wait until queue empty....
+            pass
         self.setAsync(False)
         self.main.serialchooser.write(bytes(cmd,"utf-8"))
 

--- a/serial_ui.py
+++ b/serial_ui.py
@@ -33,7 +33,7 @@ class SerialChooser(WidgetUI):
         cmd = self.lineEdit_cmd.text()+"\n"
         self.serialLog(cmd)
         #self.serial.write(bytes(cmd,"utf-8"))
-        self.main.comms.serialGetAsync(cmd,self.serialLog,readall=True)
+        self.serialLog(self.main.comms.serialGet(cmd))
 
     def write(self,data):
         self.serial.write(data)

--- a/serial_ui.py
+++ b/serial_ui.py
@@ -18,7 +18,7 @@ class SerialChooser(WidgetUI):
         self.comboBox_port.currentIndexChanged.connect(self.selectPort)
         self.pushButton_send.clicked.connect(self.sendLine)
         self.lineEdit_cmd.returnPressed.connect(self.sendLine)
-        self.serial.readyRead.connect(self.serialReceive)
+        
         self.getPorts()
 
         self.ports = []
@@ -27,26 +27,13 @@ class SerialChooser(WidgetUI):
     def serialLog(self,txt):
         self.serialLogBox.append(txt)
 
-    def setLog(self,enabled):
-        try:
-            if(enabled):
-                self.serial.readyRead.connect(self.serialReceive)
-            else:
-                self.serial.readyRead.disconnect(self.serialReceive)
-        except:
-            pass
-
-    def serialReceive(self):
-        data = self.serial.readAll()
-        text = data.data().decode("utf-8")
-        self.lastSerial = text
-        self.serialLog(text)
 
     def sendLine(self):
         
         cmd = self.lineEdit_cmd.text()+"\n"
         self.serialLog(cmd)
-        self.serial.write(bytes(cmd,"utf-8"))
+        #self.serial.write(bytes(cmd,"utf-8"))
+        self.main.comms.serialGetAsync(cmd,self.serialLog,readall=True)
 
     def write(self,data):
         self.serial.write(data)

--- a/system_ui.py
+++ b/system_ui.py
@@ -60,21 +60,21 @@ class SystemUI(WidgetUI):
         msg.exec_()
 
     def getMainClasses(self):
-        dat = self.main.comms.serialGet("lsmain\n")
-        self.comboBox_main.clear()
-        self.classIds,self.classes = classlistToIds(dat)
-        id = self.main.comms.serialGet("id?\n")
-        if(id == None):
-            #self.main.resetPort()
-            self.setEnabled(False)
-            return
+        
+        def updateMains(dat):
+            self.comboBox_main.clear()
+            self.classIds,self.classes = classlistToIds(dat)
+            id = self.main.comms.serialGet("id?\n")
+            if(id == None):
+                #self.main.resetPort()
+                self.setEnabled(False)
+                return
+            self.setEnabled(True)
+            id = int(id)
+            for c in self.classes:
+                self.comboBox_main.addItem(c[1])
+            self.comboBox_main.setCurrentIndex(self.classIds[id][0])
+            self.main.log("Detected mode: "+self.comboBox_main.currentText())
+            self.main.updateTabs()
 
-        self.setEnabled(True)
-        id = int(id)
-
-        for c in self.classes:
-            self.comboBox_main.addItem(c[1])
-        self.comboBox_main.setCurrentIndex(self.classIds[id][0])
-        self.main.log("Detected mode: "+self.comboBox_main.currentText())
-        self.main.updateTabs()
-       
+        self.main.comms.serialGetAsync("lsmain",updateMains)

--- a/system_ui.py
+++ b/system_ui.py
@@ -9,10 +9,10 @@ from base_ui import WidgetUI
 class SystemUI(WidgetUI):
     classes = []
     classIds = {}
+    mainID = None
     def __init__(self, main=None):
 
         WidgetUI.__init__(self, main,'baseclass.ui')
-
         self.setEnabled(False)
         self.pushButton_ok.clicked.connect(self.mainBtn)
         self.pushButton_reboot.clicked.connect(self.reboot)
@@ -64,17 +64,20 @@ class SystemUI(WidgetUI):
         def updateMains(dat):
             self.comboBox_main.clear()
             self.classIds,self.classes = classlistToIds(dat)
-            id = self.main.comms.serialGet("id?\n")
-            if(id == None):
+            
+            if(self.mainID == None):
                 #self.main.resetPort()
                 self.setEnabled(False)
                 return
             self.setEnabled(True)
-            id = int(id)
             for c in self.classes:
                 self.comboBox_main.addItem(c[1])
-            self.comboBox_main.setCurrentIndex(self.classIds[id][0])
+            self.comboBox_main.setCurrentIndex(self.classIds[self.mainID][0])
             self.main.log("Detected mode: "+self.comboBox_main.currentText())
             self.main.updateTabs()
 
+        def f(i):
+            self.mainID = i
+        self.main.comms.serialGetAsync("id?",f,int)
         self.main.comms.serialGetAsync("lsmain",updateMains)
+        

--- a/system_ui.py
+++ b/system_ui.py
@@ -29,17 +29,17 @@ class SystemUI(WidgetUI):
 
     def mainBtn(self):
         id = self.classes[self.comboBox_main.currentIndex()][0]
-        self.main.serialWrite("main="+str(id)+"\n")
+        self.main.comms.serialWrite("main="+str(id)+"\n")
         self.main.resetPort()
         msg = QMessageBox(QMessageBox.Information,"Main class changed","Please reconnect.\n Depending on the main class the serial port may have changed.")
         msg.exec_()
   
     def reboot(self):
-        self.main.serialWrite("reboot\n")
+        self.main.comms.serialWrite("reboot\n")
         self.main.reconnect()
     
     def dfu(self):
-        self.main.serialWrite("dfu\n")
+        self.main.comms.serialWrite("dfu\n")
         self.main.resetPort()
         msg = QMessageBox(QMessageBox.Information,"DFU","Switched to DFU mode.\nConnect with DFU programmer")
         msg.exec_()
@@ -47,8 +47,8 @@ class SystemUI(WidgetUI):
     def factoryReset(self, btn):
         cmd = btn.text()
         if(cmd=="OK"):
-            self.main.serialWrite("format=1\n")
-            self.main.serialWrite("reboot\n")
+            self.main.comms.serialWrite("format=1\n")
+            self.main.comms.serialWrite("reboot\n")
             self.main.resetPort()
 
     def factoryResetBtn(self):
@@ -60,10 +60,10 @@ class SystemUI(WidgetUI):
         msg.exec_()
 
     def getMainClasses(self):
-        dat = self.main.serialGet("lsmain\n")
+        dat = self.main.comms.serialGet("lsmain\n")
         self.comboBox_main.clear()
         self.classIds,self.classes = classlistToIds(dat)
-        id = self.main.serialGet("id?\n")
+        id = self.main.comms.serialGet("id?\n")
         if(id == None):
             #self.main.resetPort()
             self.setEnabled(False)

--- a/system_ui.py
+++ b/system_ui.py
@@ -60,7 +60,6 @@ class SystemUI(WidgetUI):
         msg.exec_()
 
     def getMainClasses(self):
-        
         def updateMains(dat):
             self.comboBox_main.clear()
             self.classIds,self.classes = classlistToIds(dat)

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -96,10 +96,12 @@ class TMC4671Ui(WidgetUI):
         try:
             # Fill encoder source types
             self.comboBox_enc.clear()
-            encsrcs = self.main.comms.serialGet("encsrc!\n")
-            for s in encsrcs.split(","):
-                e = s.split("=")
-                self.comboBox_enc.addItem(e[0],e[1])
+           
+            def encs(encsrcs):
+                for s in encsrcs.split(","):
+                    e = s.split("=")
+                    self.comboBox_enc.addItem(e[0],e[1])
+            self.main.comms.serialGetAsync("encsrc!",encs)
 
             self.getMotor()
             self.getPids()

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -23,7 +23,7 @@ class TMC4671Ui(WidgetUI):
         self.initUi()
         
 
-        self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.comms.serialWrite("fluxoffset="+str(v)+";"))
+        #self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.comms.serialWrite("fluxoffset="+str(v)+";"))
 
         self.main.setSaveBtn(True)
         

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -33,7 +33,7 @@ class TMC4671Ui(WidgetUI):
         pass
 
     def showEvent(self,event):
-        self.timer.start(50)
+        self.timer.start(40)
 
     # Tab is hidden
     def hideEvent(self,event):
@@ -52,7 +52,7 @@ class TMC4671Ui(WidgetUI):
             self.main.log("TMC update error: " + str(e)) 
 
     def updateTimer(self):
-        self.main.comms.serialGetAsync("acttorque",self.updateCurrent)
+        self.main.comms.serialGetAsync("acttrq",self.updateCurrent)
         
     
 

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -23,14 +23,8 @@ class TMC4671Ui(WidgetUI):
         self.initUi()
         
 
-        # self.spinBox_tp.valueChanged.connect(lambda v : self.main.serialWrite("torqueP="+str(v)+";"))
-        # self.spinBox_ti.valueChanged.connect(lambda v : self.main.serialWrite("torqueI="+str(v)+";"))
-        # self.spinBox_fp.valueChanged.connect(lambda v : self.main.serialWrite("fluxP="+str(v)+";"))
-        # self.spinBox_fi.valueChanged.connect(lambda v : self.main.serialWrite("fluxI="+str(v)+";"))
-        self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.serialWrite("fluxoffset="+str(v)+";"))
+        self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.comms.serialWrite("fluxoffset="+str(v)+";"))
 
-        self.pushButton_submitmotor.clicked.connect(self.submitMotor)
-        self.pushButton_submitpid.clicked.connect(self.submitPid)
         self.main.setSaveBtn(True)
         
         self.timer.timeout.connect(self.updateTimer)
@@ -45,17 +39,19 @@ class TMC4671Ui(WidgetUI):
     def hideEvent(self,event):
         self.timer.stop()
         
-    def updateTimer(self):
-        if self.main.serialBusy:
-            return
+    def updateCurrent(self,current):
         try:
-            current = float(self.main.serialGet("acttorque;"))
+            current = float(current)
             v = (2.5/0x7fff) * current
             amps = round((v / self.amp_gain) / self.shunt_ohm,3)
             self.label_Current.setText(str(amps)+"A")
 
         except Exception as e:
             self.main.log("TMC update error: " + str(e)) 
+
+    def updateTimer(self):
+        self.main.comms.serialGetAsync("acttorque",self.updateCurrent)
+        
     
 
     def submitMotor(self):
@@ -73,7 +69,7 @@ class TMC4671Ui(WidgetUI):
         
 
 
-        self.main.serialWrite(cmd)
+        self.main.comms.serialWrite(cmd)
 
     def submitPid(self):
         # PIDs
@@ -93,14 +89,14 @@ class TMC4671Ui(WidgetUI):
 
         fi = self.spinBox_fi.value()
         cmd+="fluxI="+str(fi)+";"
-        self.main.serialWrite(cmd)
+        self.main.comms.serialWrite(cmd)
 
 
     def initUi(self):
         try:
             # Fill encoder source types
             self.comboBox_enc.clear()
-            encsrcs = self.main.serialGet("encsrc!\n")
+            encsrcs = self.main.comms.serialGet("encsrc!\n")
             for s in encsrcs.split(","):
                 e = s.split("=")
                 self.comboBox_enc.addItem(e[0],e[1])
@@ -108,7 +104,7 @@ class TMC4671Ui(WidgetUI):
             self.getMotor()
             self.getPids()
 
-            self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.serialWrite("fluxoffset="+str(v)+";"))
+            self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.main.comms.serialWrite("fluxoffset="+str(v)+";"))
             self.pushButton_submitmotor.clicked.connect(self.submitMotor)
             self.pushButton_submitpid.clicked.connect(self.submitPid)
         except Exception as e:
@@ -117,31 +113,29 @@ class TMC4671Ui(WidgetUI):
         return True
 
     def alignEnc(self):
-        res = self.main.serialGet("encalign\n",3000)
+        res = self.main.comms.serialGet("encalign\n",3000)
         if(res):
             msg = QMessageBox(QMessageBox.Information,"Encoder align",res)
             msg.exec_()
 
     def getMotor(self):
-        res = self.main.serialGet("mtype?;poles?;encsrc?;")
-        mtype,poles,enc = [int(s) for s in res.split("\n")]
-        if(mtype):
-            self.comboBox_mtype.setCurrentIndex((mtype))
-        if(poles):
-            self.spinBox_poles.setValue((poles))
-        if(enc):
-            self.comboBox_enc.setCurrentIndex(enc)
-            
-            self.spinBox_cpr.setValue(int(self.main.serialGet("cprtmc?\n")))
+        commands=["mtype?","poles?","encsrc?","cprtmc?"]
+        callbacks = [self.comboBox_mtype.setCurrentIndex,
+        self.spinBox_poles.setValue,
+        self.comboBox_enc.setCurrentIndex,
+        self.spinBox_cpr.setValue]
+        self.main.comms.serialGetAsync(commands,callbacks,convert=int)
                 
 
     def getPids(self):
-        pids = [int(s) for s in self.main.serialGet("torqueP?;torqueI?;fluxP?;fluxI?;fluxoffset?;seqpi?;").split("\n")]
-        self.spinBox_tp.setValue(pids[0])
-        self.spinBox_ti.setValue(pids[1])
-        self.spinBox_fp.setValue(pids[2])
-        self.spinBox_fi.setValue(pids[3])
+        callbacks = [self.spinBox_tp.setValue,
+        self.spinBox_ti.setValue,
+        self.spinBox_fp.setValue,
+        self.spinBox_fi.setValue,
+        self.spinBox_fluxoffset.setValue,
+        self.checkBox_advancedpid.setChecked]
 
-        self.spinBox_fluxoffset.setValue(pids[4])
+        commands = ["torqueP?","torqueI?","fluxP?","fluxI?","fluxoffset?","seqpi?"]
+        
+        self.main.comms.serialGetAsync(commands,callbacks,convert=int)
 
-        self.checkBox_advancedpid.setChecked(pids[5])


### PR DESCRIPTION
Linked to the same pull request in the firmware (https://github.com/Ultrawipf/OpenFFBoard/pull/5)

In order to safely use automatic asynchronous commands every command must result in a reply with a start marker.

Every reply will start with ">" and ends with a "\n" newline. This allows for example the GUI to send a bunch of commands and receive a bunch of replies and split them at the start marker and pass the replies easily to callback functions. 
The result is a more reliable and much faster user experience with less ways for the gui to appear unresponsive.
**Please always use the new `serialGetAsync` function to read data from the board.**

This also means the start character is never allowed to be used in reply strings normally!

Commands that won't normally result in a reply like "power=1000\n" to set a value will still give back a ">OK\n" reply.
If an invalid command is received the board will reply with an error message.
For this an enum is used as a return value of the parser functions instead of the previously used bool just showing if the command was found or not in this function.

These are major changes in the communication and require a new GUI version as well.