### PR TITLE
Additional ShifterAnalog configurability to support G27.

### DIFF
--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -16,8 +16,10 @@ class ButtonOptionsDialog(OptionsDialog):
         if(id == 0): # local buttons
             self.dialog = (LocalButtonsConf(name,self.main))
         elif(id == 1):
-            self.dialog = (SPIButtonsConf(name,self.main))
+            self.dialog = (SPIButtonsConf(name,self.main,1))
         elif(id == 2):
+            self.dialog = (SPIButtonsConf(name,self.main,2))
+        elif(id == 3):
             self.dialog = (ShifterButtonsConf(name,self.main))
         
         OptionsDialog.__init__(self, self.dialog,main)
@@ -84,9 +86,13 @@ class LocalButtonsConf(OptionsDialogGroupBox):
 
 class SPIButtonsConf(OptionsDialogGroupBox):
 
-    def __init__(self,name,main):
+    def __init__(self,name,main,id):
         self.main = main
+        self.id = id
         OptionsDialogGroupBox.__init__(self,name,main)
+
+    def getPrefix(self):
+        return f"spi{self.id}_"
    
     def initUI(self):
         vbox = QVBoxLayout()
@@ -105,21 +111,21 @@ class SPIButtonsConf(OptionsDialogGroupBox):
         self.setLayout(vbox)
 
     def apply(self):
-        self.main.comms.serialWrite("spibtn_mode="+str(self.modeBox.currentData()))
-        self.main.comms.serialWrite("spi_btnnum="+str(self.numBtnBox.value()))
-        self.main.comms.serialWrite("spi_btnpol="+("1" if self.polBox.isChecked() else "0"))
+        self.main.comms.serialWrite(f"{self.getPrefix()}btn_mode="+str(self.modeBox.currentData()))
+        self.main.comms.serialWrite(f"{self.getPrefix()}btnnum="+str(self.numBtnBox.value()))
+        self.main.comms.serialWrite(f"{self.getPrefix()}btnpol="+("1" if self.polBox.isChecked() else "0"))
 
     def readValues(self):
-        self.main.comms.serialGetAsync("spi_btnnum?",self.numBtnBox.setValue,int)
+        self.main.comms.serialGetAsync(f"{self.getPrefix()}btnnum?",self.numBtnBox.setValue,int)
         self.modeBox.clear()
         def modecb(mode):
             modes = mode.split("\n")
             modes = [m.split(":") for m in modes if m]
             for m in modes:
                 self.modeBox.addItem(m[0],m[1])
-            self.main.comms.serialGetAsync("spibtn_mode?",self.modeBox.setCurrentIndex,int)
-        self.main.comms.serialGetAsync("spibtn_mode!",modecb)
-        self.main.comms.serialGetAsync("spi_btnpol?",self.polBox.setChecked,int)
+            self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode?",self.modeBox.setCurrentIndex,int)
+        self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode!",modecb)
+        self.main.comms.serialGetAsync(f"{self.getPrefix()}btnpol?",self.polBox.setChecked,int)
 
 class ShifterButtonsConf(OptionsDialogGroupBox):
 

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -1,5 +1,6 @@
+from collections import namedtuple
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QHBoxLayout, QLineEdit, QMainWindow
+from PyQt5.QtWidgets import QGridLayout, QHBoxLayout, QLineEdit, QMainWindow
 from PyQt5.QtWidgets import QDialog
 from PyQt5.QtWidgets import QWidget,QGroupBox
 from PyQt5.QtWidgets import QMessageBox,QVBoxLayout,QCheckBox,QButtonGroup,QPushButton,QLabel,QSpinBox,QComboBox
@@ -137,6 +138,8 @@ class SPIButtonsConf(OptionsDialogGroupBox):
         self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_cs?", self.csBox.setValue, int)
 
 class ShifterButtonsConf(OptionsDialogGroupBox):
+    class Mode(namedtuple('Mode', ['index', 'name', 'uses_spi', 'uses_local_reverse'])):
+        pass
 
     def __init__(self,name,main):
         self.main = main
@@ -154,56 +157,107 @@ class ShifterButtonsConf(OptionsDialogGroupBox):
         vbox = QVBoxLayout()
         vbox.addWidget(QLabel("Mode"))
         self.modeBox = QComboBox()
+        self.modeBox.currentIndexChanged.connect(self.modeBoxChanged)
         vbox.addWidget(self.modeBox)
 
         self.xPos = QLineEdit()
         self.xPos.setReadOnly(True)
         self.yPos = QLineEdit()
         self.yPos.setReadOnly(True)
+        self.gear = QLineEdit()
+        self.gear.setReadOnly(True)
 
-        posGroup = QHBoxLayout()
-        posGroup.addWidget(QLabel("X"))
-        posGroup.addWidget(self.xPos)
-        posGroup.addWidget(QLabel("Y"))
-        posGroup.addWidget(self.yPos)
+        posGroup = QGridLayout()
+        posGroup.addWidget(QLabel("X"), 1, 1)
+        posGroup.addWidget(self.xPos, 1, 2)
+        posGroup.addWidget(QLabel("Y"), 1, 3)
+        posGroup.addWidget(self.yPos, 1, 4)
+        posGroup.addWidget(QLabel("Calculated Gear"), 2, 1, 1, 2)
+        posGroup.addWidget(self.gear, 2, 3, 1, 2)
         posGroupBox = QGroupBox()
         posGroupBox.setTitle("Current")
         posGroupBox.setLayout(posGroup)
         vbox.addWidget(posGroupBox)
+
+        vbox.addWidget(QLabel("X Channel"))
+        self.xChannel = QSpinBox()
+        self.xChannel.setMinimum(1)
+        self.xChannel.setMaximum(6)
+        vbox.addWidget(self.xChannel)
+
+        vbox.addWidget(QLabel("Y Channel"))
+        self.yChannel = QSpinBox()
+        self.yChannel.setMinimum(1)
+        self.yChannel.setMaximum(6)
+        vbox.addWidget(self.yChannel)
 
         self.x12 = addThreshold("X 1,2 Threshold")
         self.x56 = addThreshold("X 5,6 Threshold")
         self.y135 = addThreshold("Y 1,3,5 Threshold")
         self.y246 = addThreshold("Y 2,4,6 Threshold")
 
-        vbox.addWidget(QLabel("Reverse Button Number"))
+        self.revBtnLabel = QLabel("Reverse Button Digital Input")
+        vbox.addWidget(self.revBtnLabel)
         self.revBtnBox = QSpinBox()
         self.revBtnBox.setMinimum(1)
-        self.revBtnBox.setMaximum(32)
+        self.revBtnBox.setMaximum(8)
         vbox.addWidget(self.revBtnBox)
+
+        self.csPinLabel = QLabel("SPI CS Pin Number")
+        vbox.addWidget(self.csPinLabel)
+        self.csPinBox = QSpinBox()
+        self.csPinBox.setMinimum(1)
+        self.csPinBox.setMaximum(3)
+        vbox.addWidget(self.csPinBox)
 
         self.setLayout(vbox)
 
         self.timer = QTimer()
         self.timer.timeout.connect(self.readXYPosition)
+
+    def onshown(self):
         self.timer.start(500)
-  
+
+    def onclose(self):
+        self.timer.stop()
+
+    def modeBoxChanged(self, _):
+        mode = self.modeBox.currentData()
+
+        if mode is not None:
+            self.revBtnLabel.setVisible(mode.uses_local_reverse)
+            self.revBtnBox.setVisible(mode.uses_local_reverse)
+            self.csPinLabel.setVisible(mode.uses_spi)
+            self.csPinBox.setVisible(mode.uses_spi)
  
     def apply(self):
-        self.main.comms.serialWrite(f"shifter_mode={self.modeBox.currentData()}")
+        self.main.comms.serialWrite(f"shifter_mode={self.modeBox.currentData().index}")
+        self.main.comms.serialWrite(f"shifter_x_chan={self.xChannel.value()}")
+        self.main.comms.serialWrite(f"shifter_y_chan={self.yChannel.value()}")
         self.main.comms.serialWrite(f"shifter_x_12={self.x12.value()}")
         self.main.comms.serialWrite(f"shifter_x_56={self.x56.value()}")
         self.main.comms.serialWrite(f"shifter_y_135={self.y135.value()}")
         self.main.comms.serialWrite(f"shifter_y_246={self.y246.value()}")
         self.main.comms.serialWrite(f"shifter_rev_btn={self.revBtnBox.value()}")
+        self.main.comms.serialWrite(f"shifter_cs_pin={self.csPinBox.value()}")
 
     def readXYPosition(self):
         def updatePosition(valueStr: str):
             x,y = valueStr.strip().split(",")
             self.xPos.setText(x)
             self.yPos.setText(y)
+
+        def updateGear(value: str):
+            value = value.strip()
+            if value == "0":
+                value = "N"
+            elif value == "7":
+                value = "R"
+            
+            self.gear.setText(value)
+
         self.main.comms.serialGetAsync("shifter_vals?",updatePosition, str)
-        
+        self.main.comms.serialGetAsync("shifter_gear?", updateGear, str)      
 
     def readValues(self):
         self.modeBox.clear()
@@ -211,13 +265,17 @@ class ShifterButtonsConf(OptionsDialogGroupBox):
             modes = mode.split("\n")
             modes = [m.split(":") for m in modes if m]
             for m in modes:
-                self.modeBox.addItem(m[0],m[1])
+                index, uses_spi, uses_local_reverse = m[1].split(',')
+                self.modeBox.addItem(m[0], ShifterButtonsConf.Mode(int(index), m[0], uses_spi == "1", uses_local_reverse == "1"))
             self.main.comms.serialGetAsync("shifter_mode?",self.modeBox.setCurrentIndex,int)
         self.main.comms.serialGetAsync("shifter_mode!",modecb)
+        self.main.comms.serialGetAsync("shifter_x_chan?",self.xChannel.setValue,int)
+        self.main.comms.serialGetAsync("shifter_y_chan?",self.yChannel.setValue,int)
         self.main.comms.serialGetAsync("shifter_x_12?",self.x12.setValue,int)
         self.main.comms.serialGetAsync("shifter_x_56?",self.x56.setValue,int)
         self.main.comms.serialGetAsync("shifter_y_135?",self.y135.setValue,int)
         self.main.comms.serialGetAsync("shifter_y_246?",self.y246.setValue,int)
         self.main.comms.serialGetAsync("shifter_rev_btn?",self.revBtnBox.setValue,int)
+        self.main.comms.serialGetAsync("shifter_cs_pin?",self.csPinBox.setValue, int)
         self.readXYPosition()
 

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -110,10 +110,17 @@ class SPIButtonsConf(OptionsDialogGroupBox):
         vbox.addWidget(self.polBox)
         self.setLayout(vbox)
 
+        vbox.addWidget(QLabel("CS #"))
+        self.csBox = QSpinBox()
+        self.csBox.setMinimum(1)
+        self.csBox.setMaximum(3)
+        vbox.addWidget(self.csBox)
+
     def apply(self):
         self.main.comms.serialWrite(f"{self.getPrefix()}btn_mode="+str(self.modeBox.currentData()))
         self.main.comms.serialWrite(f"{self.getPrefix()}btnnum="+str(self.numBtnBox.value()))
         self.main.comms.serialWrite(f"{self.getPrefix()}btnpol="+("1" if self.polBox.isChecked() else "0"))
+        self.main.comms.serialWrite(f"{self.getPrefix()}btn_cs={self.csBox.value()}")
 
     def readValues(self):
         self.main.comms.serialGetAsync(f"{self.getPrefix()}btnnum?",self.numBtnBox.setValue,int)
@@ -126,6 +133,7 @@ class SPIButtonsConf(OptionsDialogGroupBox):
             self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode?",self.modeBox.setCurrentIndex,int)
         self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode!",modecb)
         self.main.comms.serialGetAsync(f"{self.getPrefix()}btnpol?",self.polBox.setChecked,int)
+        self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_cs?", self.csBox.setValue, int)
 
 class ShifterButtonsConf(OptionsDialogGroupBox):
 

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -178,7 +178,7 @@ class ShifterButtonsConf(OptionsDialogGroupBox):
 
         vbox.addWidget(QLabel("Reverse Button Number"))
         self.revBtnBox = QSpinBox()
-        self.revBtnBox.setMinimum(0)
+        self.revBtnBox.setMinimum(1)
         self.revBtnBox.setMaximum(32)
         vbox.addWidget(self.revBtnBox)
 
@@ -218,5 +218,6 @@ class ShifterButtonsConf(OptionsDialogGroupBox):
         self.main.comms.serialGetAsync("shifter_x_56?",self.x56.setValue,int)
         self.main.comms.serialGetAsync("shifter_y_135?",self.y135.setValue,int)
         self.main.comms.serialGetAsync("shifter_y_246?",self.y246.setValue,int)
+        self.main.comms.serialGetAsync("shifter_rev_btn?",self.revBtnBox.setValue,int)
         self.readXYPosition()
 

--- a/optionsdialog.py
+++ b/optionsdialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QMainWindow
+from PyQt5.QtWidgets import QDialogButtonBox, QHBoxLayout, QMainWindow
 from PyQt5.QtWidgets import QDialog
 from PyQt5.QtWidgets import QWidget,QGroupBox
 from PyQt5.QtWidgets import QMessageBox,QVBoxLayout,QCheckBox,QButtonGroup,QPushButton,QLabel,QSpinBox,QComboBox
@@ -24,23 +24,44 @@ class OptionsDialog(QDialog):
         self.layout.addWidget(self.conf_ui)
 
         okbtn = QPushButton("OK")
-        okbtn.clicked.connect(self.apply)
-        self.layout.addWidget(okbtn)
+        okbtn.clicked.connect(self.ok)
+        cancelButton = QPushButton("Cancel")
+        cancelButton.clicked.connect(self.close)
+        applyButton = QPushButton("Apply")
+        applyButton.clicked.connect(self.apply)
+
+        btnGroup = QDialogButtonBox()
+        btnGroup.addButton(okbtn, QDialogButtonBox.AcceptRole)
+        btnGroup.addButton(cancelButton, QDialogButtonBox.RejectRole)
+        btnGroup.addButton(applyButton, QDialogButtonBox.ApplyRole)
+        self.layout.addWidget(btnGroup)
+
         self.setLayout(self.layout)
+
+    def ok(self):
+        self.apply()
+        self.close()
 
     def apply(self):
         self.conf_ui.apply()
-        self.close()
 
-    def showEvent(self,event):
+    def closeEvent(self, a0) -> None:
+        self.onclose()
+        return super().closeEvent(a0)
+
+    def onclose(self):
+        self.conf_ui.onclose()
+
+    def exec(self) -> None:
         try:
             if not self.initialized:
                 self.initBaseUI()
             self.conf_ui.readValues()
+            self.conf_ui.onshown()
         except Exception as e:
             self.main.log("Error getting info")
             print(e)
-            return
+        return super().exec()
 
     def setDialog(self,dialog):
         self.conf_ui = dialog
@@ -61,4 +82,10 @@ class OptionsDialogGroupBox(QGroupBox):
         pass
     
     def readValues(self):
+        pass
+
+    def onshown(self):
+        pass
+
+    def onclose(self):
         pass


### PR DESCRIPTION
Relates to https://github.com/Ultrawipf/OpenFFBoard/pull/9.

GUI Screenshot:
![](https://user-images.githubusercontent.com/239173/103396125-28a88b80-4ae6-11eb-8b81-9732f49f5a03.png)

The display of SPI CS Pin Number or Reverse Button Digital Input changes based on the mode selection.
