### PR TITLE
Release: support for new serial protocol in firmware

### DIFF
--- a/activelist.py
+++ b/activelist.py
@@ -1,0 +1,113 @@
+from base_ui import WidgetUI
+from PyQt5.QtWidgets import QDialog,QTableWidgetItem ,QHeaderView
+from PyQt5.QtWidgets import QMessageBox,QVBoxLayout,QCheckBox,QButtonGroup,QPushButton,QLabel,QSpinBox,QComboBox
+from PyQt5.QtCore import QAbstractTableModel,Qt,QModelIndex
+
+
+class ActiveClassModel(QAbstractTableModel):
+    def __init__(self,parent):
+        super(ActiveClassModel, self).__init__()
+        self.parent = parent
+        self.items = []
+        self.header = ["Name", "CMD addr","Instance","Classchooser ID"]
+ 
+    def data(self, index, role):
+        if role == Qt.DisplayRole:
+            idx = index.row()
+
+            d = self.items[idx]
+                
+            if(index.column() == 0):
+                return d["name"]
+            elif(index.column() == 1):
+                return d["cmdaddr"]
+            elif(index.column() == 2):
+                return d["unique"]
+            elif(index.column() == 3):
+                return d["id"]
+   
+            else:
+                return None
+
+    def headerData(self,section,orientation,role):
+        if role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
+                return self.header[section]
+
+
+    def getHeader(self):
+        return self.header
+
+    def rowCount(self, index):
+        return len(self.items)
+
+    def columnCount(self, index):
+        return len(self.header)
+
+    def clearItems(self):
+        self.beginResetModel()
+        self.items.clear()
+        self.endResetModel()
+
+    def count(self):
+        return len(self.items)
+    
+    def addItem(self,item):
+        cnt = len(self.items)
+        self.beginInsertRows(QModelIndex(),cnt,cnt)
+        self.items.append(item)
+        self.endInsertRows()
+
+    def setItems(self,items):
+        self.beginResetModel()
+        self.items = items
+        self.endResetModel()
+
+class ActiveClassDialog(QDialog):
+    def __init__(self,main=None):
+        QDialog.__init__(self, main)
+        self.main = main
+        self.ui = ActiveClassUI(main,self)
+        self.layout = QVBoxLayout()
+        self.layout.setContentsMargins(0,0,0,0)
+        self.layout.addWidget(self.ui)
+        self.setLayout(self.layout)
+        self.setWindowTitle("Active features")
+
+class ActiveClassUI(WidgetUI):
+    
+    def __init__(self, main=None,parent = None):
+        WidgetUI.__init__(self, parent,'activelist.ui')
+        self.main = main
+        self.parent = parent
+        #main.comms.serialRegisterCallback("lsactive",self.updateCb)
+        self.pushButton_refresh.clicked.connect(self.read)
+        self.items = ActiveClassModel(self.tableView)
+        self.tableView.setModel(self.items)
+        header = self.tableView.horizontalHeader()
+        header.setStretchLastSection(True)
+
+
+    def showEvent(self, a0):
+        self.tableView.resizeColumnsToContents()
+        self.read()
+
+    def read(self):
+        self.main.comms.serialGetAsync("lsactive",self.updateCb)
+
+    def updateCb(self,string):
+        self.parent.show()
+        items = []
+        for line in string.split("\n"):
+            e = line.split(":")
+            if(len(e) < 4):
+                continue
+            item = {"name":e[0], "id":e[1], "unique":e[2],"cmdaddr":e[3]}
+            items.append(item)
+        self.items.setItems(items)
+        self.tableView.resizeColumnsToContents()
+        
+
+            
+
+    

--- a/analogconf_ui.py
+++ b/analogconf_ui.py
@@ -41,8 +41,6 @@ class AnalogInputConf(OptionsDialogGroupBox,CommunicationHandler):
     def readValues(self):
         self.getValueAsync("apin","pins",self.createAinButtons,0,conversion=int)
         self.getValueAsync("apin","autocal",self.autorangeBox.setChecked,0,conversion=int)
-        #self.main.comms.serialGetAsync("local_ain_num?",self.createAinButtons,int)
-        #self.main.comms.serialGetAsync("local_ain_acal?",self.autorangeBox.setChecked,int)
         
 
     def createAinButtons(self,axes):
@@ -65,7 +63,6 @@ class AnalogInputConf(OptionsDialogGroupBox,CommunicationHandler):
         def f(axismask):
             for i in range(self.axes):
                 self.analogbtns.button(i).setChecked(axismask & (1 << i))
-        #self.main.comms.serialGetAsync("local_ain_mask?",f,int)
         self.getValueAsync("apin","mask",f,0,conversion=int)
 
     def apply(self):

--- a/analogconf_ui.py
+++ b/analogconf_ui.py
@@ -45,7 +45,6 @@ class AnalogInputConf(OptionsDialogGroupBox,CommunicationHandler):
 
     def createAinButtons(self,axes):
         self.axes = axes
-        print(axes)
         # remove buttons
         for i in range(self.buttonBoxLayout.count()):
             b = self.buttonBoxLayout.takeAt(0)
@@ -73,3 +72,6 @@ class AnalogInputConf(OptionsDialogGroupBox,CommunicationHandler):
 
         self.sendValue("apin","mask",mask)
         self.sendValue("apin","autocal",1 if self.autorangeBox.isChecked() else 0)
+
+    def onclose(self):
+        self.removeCallbacks()

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -63,15 +63,13 @@ class AxisUI(WidgetUI,CommunicationHandler):
         
         
 
-
     def initUi(self):
         try:
             self.getMotorDriver()
             self.getEncoder()
-            self.updateSliders()
+            #self.updateSliders()
             self.sendCommand("axis","invert",self.axis)
-            #self.serialGetAsync("invert?",self.checkBox_invert.setChecked,int)
-            
+       
         except:
             self.main.log("Error initializing Axis tab")
             return False
@@ -103,14 +101,11 @@ class AxisUI(WidgetUI,CommunicationHandler):
         self.label_power.setText(text)
 
     def power_changed(self,val):
-        #self.serialWrite("power="+str(val)+"\n")
         self.sendValue("axis","power",val,instance=self.axis)
         self.updatePowerLabel(val)
 
     # Effect/Endstop ratio scaler
     def fxratio_changed(self,val):
-
-        #self.serialWrite("fxratio="+str(val)+"\n")
         self.sendValue("axis","fxratio",val,instance=self.axis)
         ratio = val / 255
         text = str(round(100*ratio,1)) + "%"
@@ -120,9 +115,7 @@ class AxisUI(WidgetUI,CommunicationHandler):
         self.encoderChanged(self.comboBox_encoder.currentIndex())
 
     def submitHw(self):
-        #val = self.spinBox_cpr.value()
         self.driverChanged(self.comboBox_driver.currentIndex())
-        #self.serialWrite("cpr="+str(val)+"\n")
 
 
     def driverChanged(self,idx):
@@ -131,7 +124,6 @@ class AxisUI(WidgetUI,CommunicationHandler):
         id = self.drvClasses[idx][0]
         if(self.drvId != id):
             self.sendValue("axis","drvtype",id,instance=self.axis)
-            #self.serialWrite("drvtype="+str(id)+"\n")
             self.getMotorDriver()
             self.getEncoder()
             self.main.updateTabs()
@@ -150,25 +142,16 @@ class AxisUI(WidgetUI,CommunicationHandler):
         
     
     def updateSliders(self):
-        #commands = ["power?","degrees?","fxratio?","esgain?","idlespring?","axisdamper?"]
         if(self.drvId == 1 or self.drvId == 2): # Reduce max range for TMC (ADC saturation margin. Recommended to keep <25000)
             self.horizontalSlider_power.setMaximum(28000)
             self.getValueAsync("tmc","iScale",self.setCurrentScaler,self.drvId - 1,float)
             #self.serialGetAsync("tmcIscale?",self.setCurrentScaler,convert=float)       
         else:
             self.horizontalSlider_power.setMaximum(0x7fff)
-        # callbacks = [
-        # self.horizontalSlider_power.setValue,
-        # self.horizontalSlider_degrees.setValue,
-        # self.horizontalSlider_fxratio.setValue,
-        # self.horizontalSlider_esgain.setValue,
-        # self.horizontalSlider_idle.setValue,
-        # self.horizontalSlider_damper.setValue]
+
         commands = ["power","degrees","fxratio","esgain","idlespring","axisdamper"] # requests updates
         self.sendCommands("axis",commands,self.axis)
 
-        
-        #self.serialGetAsync(commands,callbacks,convert=int)
         self.updatePowerLabel(self.horizontalSlider_power.value())
 
     def drvtypecb(self,i):
@@ -214,7 +197,6 @@ class AxisUI(WidgetUI,CommunicationHandler):
                     self.encWidgets[id] = EncoderOptions(self.main,id)
                     self.stackedWidget_encoder.addWidget(self.encWidgets[id])
 
-        #self.serialGetAsync("enctype!",f)
         self.getValueAsync("axis","enctype",f,self.axis,str,typechar='!')
         
         def encid_f(id):
@@ -232,12 +214,4 @@ class AxisUI(WidgetUI,CommunicationHandler):
             self.comboBox_encoder.setCurrentIndex(idx)
             self.encoderIndexChanged(idx)
             
-            # if(self.encId == 1):
-            #     self.spinBox_cpr.setEnabled(False)
-        #self.serialGetAsync("enctype?",encid_f,int)
         self.getValueAsync("axis","enctype",encid_f,self.axis,int,typechar='?')
-        # def f_cpr(v):
-        #     self.spinBox_cpr.setValue(v)
-        # self.serialGetAsync("cpr?",f_cpr,int)
-
-        

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -8,10 +8,10 @@ from PyQt5.QtCore import QTimer,QEvent
 import main
 import buttonconf_ui
 import analogconf_ui
-from base_ui import WidgetUI
+from base_ui import WidgetUI,CommunicationHandler
 from encoderconf_ui import EncoderOptions
 
-class AxisUI(WidgetUI):
+class AxisUI(WidgetUI,CommunicationHandler):
     adc_to_amps = 0.0
     
     drvClasses = {}
@@ -28,6 +28,7 @@ class AxisUI(WidgetUI):
 
     def __init__(self, main=None, unique='X'):
         WidgetUI.__init__(self, main, 'axis_ui.ui')
+        CommunicationHandler.__init__(self)
 
         self.axis = unique
 

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -47,9 +47,7 @@ class AxisUI(WidgetUI,CommunicationHandler):
         self.horizontalSlider_damper.valueChanged.connect(lambda val : self.sendValue("axis","axisdamper",val,instance=self.axis))
         self.pushButton_center.clicked.connect(lambda : self.sendCommand("axis","zeroenc",instance=self.axis))
         
-        #self.comboBox_encoder.currentIndexChanged.connect(self.encoderIndexChanged)
-
-        self.checkBox_invert.stateChanged.connect(lambda val : self.sendValue("axis","invert",(1 if val == 0 else 0),instance=self.axis))
+        self.checkBox_invert.stateChanged.connect(lambda val : self.sendValue("axis","invert",(0 if val == 0 else 1),instance=self.axis))
 
         self.pushButton_submit_hw.clicked.connect(self.submitHw)
         self.pushButton_submit_enc.clicked.connect(self.submitEnc)

--- a/base_ui.py
+++ b/base_ui.py
@@ -14,26 +14,28 @@ class WidgetUI(QWidget):
 
     def initUi(self):
         return True
+        
 
 
 class CommunicationHandler():
     comms: SerialComms = None
     def __init__(self):
         #self.comms = comms
-        print("Newclass")
+        #print("Newclass")
+        pass
 
     def __del__(self):
         # remove callbacks
-        print("Delclass")
+        #print("Delclass")
         self.removeCallbacks()
         
     # deletes all callbacks to this class
     def removeCallbacks(self):
-        self.comms.removeCallbacks(self)
+        SerialComms.removeCallbacks(self)
 
     # Helper function to register a callback that can be deleted automatically later
     def registerCallback(self,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
-        self.comms.registerCallback(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
+        SerialComms.registerCallback(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
 
     def getValueAsync(self,cls,cmd,callback,instance=0,conversion=None,adr=None,typechar='?',delete=True):
         self.comms.getValueAsync(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,typechar=typechar,delete=delete)

--- a/base_ui.py
+++ b/base_ui.py
@@ -34,10 +34,11 @@ class CommunicationHandler():
         SerialComms.removeCallbacks(self)
 
     # Helper function to register a callback that can be deleted automatically later
+    # Callbacks normally must prevent sending a value change command in this callback to prevent the same value from being sent back again
     def registerCallback(self,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
         SerialComms.registerCallback(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
 
-    def getValueAsync(self,cls,cmd,callback,instance=0,conversion=None,adr=None,typechar='?',delete=True):
+    def getValueAsync(self,cls,cmd,callback,instance : int=0,conversion=None,adr=None,typechar='?',delete=True):
         self.comms.getValueAsync(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,typechar=typechar,delete=delete)
 
     def serialWriteRaw(self,cmd):

--- a/base_ui.py
+++ b/base_ui.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QWidget
 from helper import res_path
 from PyQt5 import uic
 import main
+from serial_comms import SerialComms
 
 class WidgetUI(QWidget):
     
@@ -13,3 +14,42 @@ class WidgetUI(QWidget):
 
     def initUi(self):
         return True
+
+
+class CommunicationHandler():
+    comms: SerialComms = None
+    def __init__(self):
+        #self.comms = comms
+        print("Newclass")
+
+    def __del__(self):
+        # remove callbacks
+        print("Delclass")
+        self.removeCallbacks()
+        
+    # deletes all callbacks to this class
+    def removeCallbacks(self):
+        self.comms.removeCallbacks(self)
+
+    # Helper function to register a callback that can be deleted automatically later
+    def registerCallback(self,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
+        self.comms.registerCallback(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
+
+    def getValueAsync(self,cls,cmd,callback,instance=0,conversion=None,adr=None,typechar='?',delete=True):
+        self.comms.getValueAsync(self,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,typechar=typechar,delete=delete)
+
+    def serialWriteRaw(self,cmd):
+        self.comms.serialWriteRaw(cmd)
+    
+    def sendValue(self,cls,cmd,val,adr=None,instance=0):
+        self.comms.sendValue(self,cls=cls,cmd=cmd,val=val,adr=adr,instance=instance)
+
+    def sendCommand(self,cls,cmd,instance=0,typechar = '?'):
+        self.comms.sendCommand(cls,cmd,instance=instance,typechar=typechar)
+
+    def sendCommands(self,cls,cmds,instance=0,typechar = '?'):
+        cmdstring = ""
+        for cmd in cmds:
+            cmdstring += f"{cls}.{instance}.{cmd}{typechar};"
+        self.comms.serialWriteRaw(cmdstring)
+        

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -48,7 +48,8 @@ class LocalButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
         
         self.setLayout(vbox)
 
-
+    def onclose(self):
+            self.removeCallbacks()
     def initButtons(self,num):
         #delete buttons
         self.num = num
@@ -123,6 +124,10 @@ class SPIButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
         self.sendValue("spibtn","btnnum",self.numBtnBox.value(),instance=self.id)
         self.sendValue("spibtn","btnpol",1 if self.polBox.isChecked() else 0,instance=self.id)
         self.sendValue("spibtn","btn_cs",self.csBox.value(),instance=self.id)
+
+    def onclose(self):
+        self.removeCallbacks()
+
      
     def readValues(self):
 
@@ -224,6 +229,7 @@ class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
 
     def onclose(self):
         self.timer.stop()
+        self.removeCallbacks()
 
     def modeBoxChanged(self, _):
         mode = self.modeBox.currentData()

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -84,10 +84,8 @@ class LocalButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
     
     def readValues(self):
         self.getValueAsync("dpin","pins",self.initButtons,0,conversion=int)
-        #self.main.comms.serialGetAsync("local_btnpins?",self.initButtons,int)
         self.getValueAsync("dpin","polarity",self.polBox.setChecked,0,conversion=int)
-        #self.main.comms.serialGetAsync("local_btnpol?",self.polBox.setChecked,int)
-
+ 
 
 class SPIButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
 
@@ -237,15 +235,15 @@ class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
             self.csPinBox.setVisible(mode.uses_spi)
  
     def apply(self):
-        self.sendValue("spibtn","mode",self.modeBox.currentData().index)
-        self.sendValue("spibtn","xchan",self.xChannel.value())
-        self.sendValue("spibtn","ychan",self.yChannel.value())
-        self.sendValue("spibtn","x12",self.x12.value())
-        self.sendValue("spibtn","x56",self.x56.value())
-        self.sendValue("spibtn","y135",self.y135.value())
-        self.sendValue("spibtn","y246",self.y246.value())
-        self.sendValue("spibtn","revbtn",self.revBtnBox.value())
-        self.sendValue("spibtn","cspin",self.csPinBox.value())
+        self.sendValue("shifter","mode",self.modeBox.currentData().index)
+        self.sendValue("shifter","xchan",self.xChannel.value())
+        self.sendValue("shifter","ychan",self.yChannel.value())
+        self.sendValue("shifter","x12",self.x12.value())
+        self.sendValue("shifter","x56",self.x56.value())
+        self.sendValue("shifter","y135",self.y135.value())
+        self.sendValue("shifter","y246",self.y246.value())
+        self.sendValue("shifter","revbtn",self.revBtnBox.value())
+        self.sendValue("shifter","cspin",self.csPinBox.value())
 
     def readXYPosition(self):
         def updatePosition(valueStr: str):

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -125,14 +125,9 @@ class SPIButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
         self.sendValue("spibtn","btnnum",self.numBtnBox.value(),instance=self.id)
         self.sendValue("spibtn","btnpol",1 if self.polBox.isChecked() else 0,instance=self.id)
         self.sendValue("spibtn","btn_cs",self.csBox.value(),instance=self.id)
-        #self.main.comms.serialWrite(f"{self.getPrefix()}btn_mode="+str(self.modeBox.currentData()))
-        #self.main.comms.serialWrite(f"{self.getPrefix()}btnnum="+str(self.numBtnBox.value()))
-        #self.main.comms.serialWrite(f"{self.getPrefix()}btnpol="+("1" if self.polBox.isChecked() else "0"))
-        #self.main.comms.serialWrite(f"{self.getPrefix()}btn_cs={self.csBox.value()}")
-
+     
     def readValues(self):
-        
-        #self.main.comms.serialGetAsync(f"{self.getPrefix()}btnnum?",self.numBtnBox.setValue,int)
+
         self.modeBox.clear()
         def modecb(mode):
             modes = mode.split("\n")
@@ -140,14 +135,12 @@ class SPIButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
             for m in modes:
                 self.modeBox.addItem(m[0],m[1])
             self.getValueAsync("spibtn","mode",self.modeBox.setCurrentIndex,self.id,conversion=int)
-            #self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode?",self.modeBox.setCurrentIndex,int)
+            
         self.getValueAsync("spibtn","btnnum",self.numBtnBox.setValue,self.id,conversion=int)
         self.getValueAsync("spibtn","mode",modecb,self.id,conversion=str,typechar='!')
-        #self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_mode!",modecb)
         self.getValueAsync("spibtn","btnpol",self.polBox.setChecked,self.id,conversion=int)
-        #self.main.comms.serialGetAsync(f"{self.getPrefix()}btnpol?",self.polBox.setChecked,int)
         self.getValueAsync("spibtn","cs",self.csBox.setValue,self.id,conversion=int)
-        #self.main.comms.serialGetAsync(f"{self.getPrefix()}btn_cs?", self.csBox.setValue, int)
+
 
 class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
     class Mode(namedtuple('Mode', ['index', 'name', 'uses_spi', 'uses_local_reverse'])):
@@ -269,9 +262,7 @@ class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
             
             self.gear.setText(value)
         self.getValueAsync("shifter","vals",updatePosition,0,conversion=str)
-        #self.main.comms.serialGetAsync("vals?",updatePosition, str)
-        self.getValueAsync("shifter","gear",updateGear,0,conversion=str)
-        #self.main.comms.serialGetAsync("shifter_gear?", updateGear, str)      
+        self.getValueAsync("shifter","gear",updateGear,0,conversion=str)  
 
     def readValues(self):
         self.modeBox.clear()
@@ -281,10 +272,8 @@ class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
             for m in modes:
                 index, uses_spi, uses_local_reverse = m[1].split(',')
                 self.modeBox.addItem(m[0], ShifterButtonsConf.Mode(int(index), m[0], uses_spi == "1", uses_local_reverse == "1"))
-            #self.main.comms.serialGetAsync("shifter_mode?",self.modeBox.setCurrentIndex,int)
             self.getValueAsync("shifter","mode",self.modeBox.setCurrentIndex,0,conversion=int)
         self.getValueAsync("shifter","mode",modecb,0,conversion=str,typechar = '!')
-        #self.main.comms.serialGetAsync("shifter_mode!",modecb)
         self.getValueAsync("shifter","xchan",self.xChannel.setValue,0,conversion=int)
         self.getValueAsync("shifter","ychan",self.yChannel.setValue,0,conversion=int)
 

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ def saveDump(buf):
     for l in buf.split("\n"):
         if not l:
             break
-        addr,val = l.split(":")
+        val,addr = l.split(":")
         dump["flash"].append({"addr":addr,"val":val})
     fname,_ = QFileDialog.getSaveFileName( directory = 'dump.json' ,filter  = "Json files (*.json)")
     try:

--- a/encoderconf_ui.py
+++ b/encoderconf_ui.py
@@ -26,6 +26,9 @@ class EncoderOptions(QGroupBox):
         elif(id == 1): # tmc
             layout.addWidget(QLabel("Configure in TMC tab"))
             found = False
+        elif(id == 4): # MT SPI
+            self.widget = (MtEncoderConf(self,self.main))
+            self.setTitle("SPI Settings")
         else:
             layout.addWidget(QLabel("No settings"))
 
@@ -85,3 +88,27 @@ class LocalEncoderConf(EncoderOption):
     def apply(self):
         val = self.spinBox_cpr.value()
         self.main.comms.serialWrite("cpr="+str(val)+"\n")
+
+
+class MtEncoderConf(EncoderOption):
+    def __init__(self,parent,main):
+        self.main = main
+        super().__init__(parent)
+        self.initUI()
+        
+
+    def initUI(self):
+        layout = QFormLayout()
+
+        self.spinBox_cs = QSpinBox()
+        self.spinBox_cs.setRange(1,3)
+        layout.addWidget(QLabel("SPI3 extension port"))
+        layout.addRow(QLabel("CS pin"),self.spinBox_cs)
+        self.setLayout(layout)
+
+    def onshown(self):
+        self.main.comms.serialGetAsync("mtenc_cs",self.spinBox_cs.setValue,int) 
+
+    def apply(self):
+        val = self.spinBox_cs.value()
+        self.main.comms.serialWrite("mtenc_cs="+str(val)+"\n")

--- a/encoderconf_ui.py
+++ b/encoderconf_ui.py
@@ -6,6 +6,7 @@ from PyQt5 import uic
 import main
 from PyQt5.QtCore import QObjectCleanupHandler
 from helper import res_path,classlistToIds
+from base_ui import CommunicationHandler
 
 class EncoderOptions(QGroupBox):
     widget = None
@@ -66,10 +67,11 @@ class EncoderOption(QWidget):
     def onclose(self):
         pass
 
-class LocalEncoderConf(EncoderOption):
+class LocalEncoderConf(EncoderOption,CommunicationHandler):
     def __init__(self,parent,main):
         self.main = main
-        super().__init__(parent)
+        EncoderOption.__init__(self,parent)
+        CommunicationHandler.__init__(self)
         self.initUI()
         
 
@@ -83,17 +85,18 @@ class LocalEncoderConf(EncoderOption):
         self.setLayout(layout)
 
     def onshown(self):
-        self.main.comms.serialGetAsync("cpr",self.spinBox_cpr.setValue,int) 
+        self.getValueAsync("localenc","cpr",self.spinBox_cpr.setValue,int)
 
     def apply(self):
         val = self.spinBox_cpr.value()
-        self.main.comms.serialWrite("cpr="+str(val)+"\n")
+        self.sendValue("localenc","cpr",val=val)
 
 
-class MtEncoderConf(EncoderOption):
+class MtEncoderConf(EncoderOption,CommunicationHandler):
     def __init__(self,parent,main):
         self.main = main
-        super().__init__(parent)
+        EncoderOption.__init__(self,parent)
+        CommunicationHandler.__init__(self)
         self.initUI()
         
 
@@ -107,8 +110,8 @@ class MtEncoderConf(EncoderOption):
         self.setLayout(layout)
 
     def onshown(self):
-        self.main.comms.serialGetAsync("mtenc_cs",self.spinBox_cs.setValue,int) 
+        self.getValueAsync("mtenc","cs",self.spinBox_cs.setValue,int)
 
     def apply(self):
         val = self.spinBox_cs.value()
-        self.main.comms.serialWrite("mtenc_cs="+str(val)+"\n")
+        self.sendValue("mtenc","cs",val=val)

--- a/encoderconf_ui.py
+++ b/encoderconf_ui.py
@@ -85,7 +85,7 @@ class LocalEncoderConf(EncoderOption,CommunicationHandler):
         self.setLayout(layout)
 
     def onshown(self):
-        self.getValueAsync("localenc","cpr",self.spinBox_cpr.setValue,int)
+        self.getValueAsync("localenc","cpr",self.spinBox_cpr.setValue,0,int)
 
     def apply(self):
         val = self.spinBox_cpr.value()
@@ -110,7 +110,7 @@ class MtEncoderConf(EncoderOption,CommunicationHandler):
         self.setLayout(layout)
 
     def onshown(self):
-        self.getValueAsync("mtenc","cs",self.spinBox_cs.setValue,int)
+        self.getValueAsync("mtenc","cs",self.spinBox_cs.setValue,0,int)
 
     def apply(self):
         val = self.spinBox_cs.value()

--- a/errors.py
+++ b/errors.py
@@ -78,7 +78,7 @@ class ErrorsUI(WidgetUI,CommunicationHandler):
         CommunicationHandler.__init__(self)
         self.main = main
         self.parent = parent
-        self.registerCallback("err","error",self.errorCallback)
+        self.registerCallback("err","error",self.errorCallback,0,typechar='')
         self.pushButton_refresh.clicked.connect(self.readErrors)
         self.pushButton_clearAll.clicked.connect(self.clearErrors)
         self.errors = ErrorsModel(self.tableView)

--- a/errors.py
+++ b/errors.py
@@ -70,6 +70,9 @@ class ErrorsDialog(QDialog):
         self.layout.addWidget(self.ui)
         self.setLayout(self.layout)
         self.setWindowTitle("Errors")
+        
+    def registerCallbacks(self):
+        self.ui.registerCallbacks()
 
 class ErrorsUI(WidgetUI,CommunicationHandler):
     
@@ -78,18 +81,21 @@ class ErrorsUI(WidgetUI,CommunicationHandler):
         CommunicationHandler.__init__(self)
         self.main = main
         self.parent = parent
-        self.registerCallback("err","error",self.errorCallback,0,typechar='')
         self.pushButton_refresh.clicked.connect(self.readErrors)
         self.pushButton_clearAll.clicked.connect(self.clearErrors)
         self.errors = ErrorsModel(self.tableView)
         self.tableView.setModel(self.errors)
         header = self.tableView.horizontalHeader()
         header.setStretchLastSection(True)
+        self.registerCallbacks()
 
 
     def clearErrors(self):
         self.sendCommand("sys","errorsclr")
         self.readErrors()
+
+    def registerCallbacks(self):
+        self.registerCallback("err","error",self.errorCallback,0,typechar='')
 
     def showEvent(self, a0):
         self.tableView.resizeColumnsToContents()

--- a/errors.py
+++ b/errors.py
@@ -95,7 +95,7 @@ class ErrorsUI(WidgetUI,CommunicationHandler):
         self.readErrors()
 
     def registerCallbacks(self):
-        self.registerCallback("err","error",self.errorCallback,0,typechar='')
+        self.registerCallback("sys","errors",self.errorCallback,0,typechar='?')
 
     def showEvent(self, a0):
         self.tableView.resizeColumnsToContents()
@@ -103,13 +103,13 @@ class ErrorsUI(WidgetUI,CommunicationHandler):
 
     def readErrors(self):
         if(self.isEnabled):
-            self.getValueAsync("sys","errors",self.errorCallback)
+            self.sendCommand("sys","errors",0)
 
     def errorCallback(self,errorstring):
         self.parent.show()
         errors = []
         for errorline in errorstring.split("\n"):
-            e = errorline.split(":")
+            e = errorline.split(":",2)
             if(len(e) < 3):
                 continue
             error = {"code":e[0], "level":e[1], "info":e[2]}

--- a/errors.py
+++ b/errors.py
@@ -2,7 +2,7 @@ from base_ui import WidgetUI
 from PyQt5.QtWidgets import QDialog,QTableWidgetItem ,QHeaderView
 from PyQt5.QtWidgets import QMessageBox,QVBoxLayout,QCheckBox,QButtonGroup,QPushButton,QLabel,QSpinBox,QComboBox
 from PyQt5.QtCore import QAbstractTableModel,Qt,QModelIndex
-
+from base_ui import CommunicationHandler
 
 class ErrorsModel(QAbstractTableModel):
     def __init__(self,parent):
@@ -71,13 +71,14 @@ class ErrorsDialog(QDialog):
         self.setLayout(self.layout)
         self.setWindowTitle("Errors")
 
-class ErrorsUI(WidgetUI):
+class ErrorsUI(WidgetUI,CommunicationHandler):
     
     def __init__(self, main=None,parent = None):
         WidgetUI.__init__(self, parent,'errors.ui')
+        CommunicationHandler.__init__(self)
         self.main = main
         self.parent = parent
-        main.comms.serialRegisterCallback("Err",self.errorCallback)
+        self.registerCallback("err","error",self.errorCallback)
         self.pushButton_refresh.clicked.connect(self.readErrors)
         self.pushButton_clearAll.clicked.connect(self.clearErrors)
         self.errors = ErrorsModel(self.tableView)
@@ -87,7 +88,7 @@ class ErrorsUI(WidgetUI):
 
 
     def clearErrors(self):
-        self.main.comms.serialWrite("errorsclr\n")
+        self.sendCommand("sys","errorsclr")
         self.readErrors()
 
     def showEvent(self, a0):
@@ -96,7 +97,7 @@ class ErrorsUI(WidgetUI):
 
     def readErrors(self):
         if(self.isEnabled):
-            self.main.comms.serialGetAsync("errors",self.errorCallback)
+            self.getValueAsync("sys","errors",self.errorCallback)
 
     def errorCallback(self,errorstring):
         self.parent.show()

--- a/ffb_ui.py
+++ b/ffb_ui.py
@@ -40,7 +40,7 @@ class FfbUI(WidgetUI,CommunicationHandler):
 
         self.horizontalSlider_cffilter.valueChanged.connect(self.cffilter_changed)
 
-        self.horizontalSlider_CFq.valueChanged.connect(lambda val : self.sliderChangedUpdateSpinbox(val,self.doubleSpinBox_CFq,0.01,"ffbfiltercf_q"))
+        self.horizontalSlider_CFq.valueChanged.connect(lambda val : self.sliderChangedUpdateSpinbox(val,self.doubleSpinBox_CFq,0.01,"filterCfQ"))
         self.doubleSpinBox_CFq.valueChanged.connect(lambda val : self.horizontalSlider_CFq.setValue(val * 100))
 
         self.doubleSpinBox_spring.valueChanged.connect(lambda val : self.horizontalSlider_spring.setValue(val * 64))

--- a/ffb_ui.py
+++ b/ffb_ui.py
@@ -309,50 +309,6 @@ class FfbUI(WidgetUI,CommunicationHandler):
         self.groupBox_analogaxes.setLayout(layout)
         
 
-    # def getAxisSources(self):
-        
-    #     def cb_axisSources(dat):
-    #         btns = dat[0]
-    #         types = int(dat[1])
-            
-    #         self.axisIds,self.axisClasses = classlistToIds(btns)
-    #         if(types == None):
-    #             self.main.log("Error getting buttons")
-    #             return
-    #         types = int(types)
-    #         layout = QGridLayout()
-    #         #clear
-    #         for b in self.axisconfbuttons:
-    #             del b
-    #         for b in self.axisbtns.buttons():
-    #             self.axisbtns.removeButton(b)
-    #             del b
-    #         #add buttons
-    #         row = 0
-    #         for c in self.axisClasses:
-    #             creatable = c[2]
-    #             btn=QCheckBox(str(c[1]),self.groupBox_buttons)
-    #             self.axisbtns.addButton(btn,c[0])
-    #             layout.addWidget(btn,row,0)
-    #             enabled = types & (1<<c[0]) != 0
-    #             btn.setChecked(enabled)
-
-    #             confbutton = QToolButton(self)
-    #             confbutton.setText(">")
-    #             layout.addWidget(confbutton,row,1)
-    #             self.axisconfbuttons.append((confbutton,analogconf_ui.AnalogOptionsDialog(str(c[1]),c[0],self.main)))
-    #             confbutton.clicked.connect(self.axisconfbuttons[row][1].exec)
-    #             confbutton.setEnabled(enabled)
-    #             self.axisbtns.button(c[0]).stateChanged.connect(confbutton.setEnabled)
-    #             row+=1
-       
-    #             confbutton.setEnabled(creatable or enabled)
-    #             btn.setEnabled(creatable or enabled)
-
-    #         self.groupBox_analogaxes.setLayout(layout)
-    #     self.main.comms.serialGetAsync(["lsain","aintypes?"],cb_axisSources)
-        
-
     def cffilter_changed(self,v,send=True):
         freq = max(min(v,500),0)
         if(send):

--- a/ffb_ui.py
+++ b/ffb_ui.py
@@ -358,7 +358,7 @@ class FfbUI(WidgetUI,CommunicationHandler):
         if(send):
             self.sendValue("fx","filterCfFreq",(freq))
         else:
-            self.horizontalSlider_CFq.setValue(v)
+            self.horizontalSlider_cffilter.setValue(v)
         lbl = str(freq)+"Hz"
         
         qOn = True

--- a/helper.py
+++ b/helper.py
@@ -33,3 +33,7 @@ def updateClassComboBox(combobox,ids,classes,selected = None):
     
     if(selected in ids and combobox.currentIndex() != ids[selected][0]):
         combobox.setCurrentIndex(ids[selected][0])
+
+def splitListReply(reply,itemdelim = ':', entrydelim = '\n'):
+    #for line in reply.split(entrydelim):
+    return [ line.split(itemdelim) for line in reply.split(entrydelim) ]

--- a/helper.py
+++ b/helper.py
@@ -1,6 +1,8 @@
 from os import path
 import sys
 
+from PyQt5.QtCore import QObject
+
 respath = "res"
 def res_path(file):
     if getattr(sys, 'frozen',False) and hasattr(sys, '_MEIPASS'):
@@ -37,3 +39,9 @@ def updateClassComboBox(combobox,ids,classes,selected = None):
 def splitListReply(reply,itemdelim = ':', entrydelim = '\n'):
     #for line in reply.split(entrydelim):
     return [ line.split(itemdelim) for line in reply.split(entrydelim) ]
+
+
+def qtBlockAndCall(object : QObject,function,value):
+    object.blockSignals(True)
+    function(value)
+    object.blockSignals(False)

--- a/main.py
+++ b/main.py
@@ -14,11 +14,11 @@ from dfu_ui import DFUModeUI
 from base_ui import CommunicationHandler
 
 # This GUIs version
-version = "1.5.0"
+version = "1.5.1"
 
 # Minimal supported firmware version. 
 # Major version of firmware must match firmware. Minor versions must be higher or equal
-min_fw = "1.5.0"
+min_fw = "1.5.1"
 
 # UIs
 import system_ui

--- a/main.py
+++ b/main.py
@@ -119,8 +119,7 @@ class MainUi(QMainWindow,CommunicationHandler):
         if not dump:
             return
         for e in dump["flash"]:
-            cmd = "sys.flashraw?{}={}\n".format(e["addr"], e["val"])
-            self.comms.serialWriteRaw(cmd)
+            self.comms.sendValue(self,"sys","flashraw",e["val"],e["addr"],0)
         # Message
         msg = QMessageBox(QMessageBox.Information,"Restore flash dump","Uploaded flash dump.\nPlease reboot.")
         msg.exec_()

--- a/main.py
+++ b/main.py
@@ -244,7 +244,7 @@ class MainUi(QMainWindow,CommunicationHandler):
 
     def reconnect(self):
         self.resetPort()
-        QTimer.singleShot(4000,self.serialchooser.serialConnect)
+        QTimer.singleShot(1000,self.serialchooser.serialConnect)
         #self.serialchooser.serialConnect()
 
     def resetPort(self):

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ class MainUi(QMainWindow,CommunicationHandler):
         def updateTabs_cb(active):
             #print(f"tabs:{active}")
             lines = [l.split(":") for l in active.split("\n") if l]
-            newActiveClasses = {i[1]+":"+i[3]:{"name":i[0],"clsname":i[1],"id":int(i[2]),"unique":int(i[3]),"ui":None,"cmdaddr":[4]} for i in lines}
+            newActiveClasses = {i[1]+":"+i[2]:{"name":i[0],"clsname":i[1],"id":int(i[3]),"unique":int(i[2]),"ui":None,"cmdaddr":[4]} for i in lines}
             deleteClasses = [(c,name) for name,c in self.activeClasses.items() if name not in newActiveClasses]
             #print(newActiveClasses)
             for c,name in deleteClasses:

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ import serial_ui
 from dfu_ui import DFUModeUI
 
 # This GUIs version
-version = "1.4.2"
+version = "1.4.3"
 
 # Minimal supported firmware version. 
 # Major version of firmware must match firmware. Minor versions must be higher or equal

--- a/main.py
+++ b/main.py
@@ -299,6 +299,7 @@ class MainUi(QMainWindow,CommunicationHandler):
             self.serialTim.singleShot(500,t)
             self.getValueAsync("main","id",f,0)
             #self.comms.serialGetAsync("id?",f)  
+            self.errorsDialog.registerCallbacks()
 
         else:
             self.connected = False

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ class MainUi(QMainWindow,CommunicationHandler):
         def updateTabs_cb(active):
             #print(f"tabs:{active}")
             lines = [l.split(":") for l in active.split("\n") if l]
-            newActiveClasses = {i[1]+":"+i[2]:{"name":i[0],"clsname":i[1],"id":int(i[2]),"unique":int(i[3]),"ui":None,"cmdaddr":[4]} for i in lines}
+            newActiveClasses = {i[1]+":"+i[3]:{"name":i[0],"clsname":i[1],"id":int(i[2]),"unique":int(i[3]),"ui":None,"cmdaddr":[4]} for i in lines}
             deleteClasses = [(c,name) for name,c in self.activeClasses.items() if name not in newActiveClasses]
             #print(newActiveClasses)
             for c,name in deleteClasses:

--- a/main.py
+++ b/main.py
@@ -51,8 +51,6 @@ class MainUi(QMainWindow,CommunicationHandler):
         CommunicationHandler.comms = serial_comms.SerialComms(self,self.serial)
         #self.serial.moveToThread(self.serialThread)
 
-        
-
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.updateTimer)
         self.tabWidget_main.currentChanged.connect(self.tabChanged)
@@ -101,7 +99,7 @@ class MainUi(QMainWindow,CommunicationHandler):
 
 
     def dfuUploader(self):
-        msg = QDialog()#QMessageBox(QMessageBox.Information,"DFU","Switched to DFU mode.\nConnect with DFU programmer")
+        msg = QDialog()
         msg.setWindowTitle("DFU Mode")
         dfu = DFUModeUI(msg)
         l = QVBoxLayout()

--- a/midi_ui.py
+++ b/midi_ui.py
@@ -3,15 +3,18 @@ from helper import res_path
 from PyQt5 import uic
 import main
 from base_ui import WidgetUI
-class MidiUI(WidgetUI):
+from base_ui import CommunicationHandler
+
+class MidiUI(WidgetUI,CommunicationHandler):
     def __init__(self, main=None):
         WidgetUI.__init__(self, main,'midi.ui')
+        CommunicationHandler.__init__(self)
         
         self.initUi()
-        self.horizontalSlider_power.valueChanged.connect(lambda val : self.main.comms.serialWrite("power="+str(val)))
-        self.horizontalSlider_amp.valueChanged.connect(lambda val : self.main.comms.serialWrite("range="+str(val)))
-        
+        self.horizontalSlider_power.valueChanged.connect(lambda val : self.sendValue("midi","power",val))
+        self.horizontalSlider_amp.valueChanged.connect(lambda val : self.sendValue("midi","range",val))
+
 
     def initUi(self):
-        self.main.comms.serialGetAsync("power?",self.horizontalSlider_power.setValue,int)
-        self.main.comms.serialGetAsync("range?",self.horizontalSlider_amp.setValue,int)
+        self.registerCallback("midi","power",self.horizontalSlider_power.setValue,0,int)
+        self.registerCallback("midi","range",self.horizontalSlider_amp.setValue,0,int)

--- a/odrive_ui.py
+++ b/odrive_ui.py
@@ -29,7 +29,7 @@ class OdriveUI(WidgetUI,CommunicationHandler):
 
         self.registerCallback("odrv","canid",self.spinBox_id.setValue,self.prefix,int)
         self.registerCallback("odrv","canspd",self.updateCanSpd,self.prefix,int)
-        self.registerCallback("odrv","maxtorqe",self.updateTorque,self.prefix,int)
+        self.registerCallback("odrv","maxtorque",self.updateTorque,self.prefix,int)
         self.registerCallback("odrv","vbus",lambda v : self.label_voltage.setText("{}V".format(v/1000)),self.prefix,int)
         self.registerCallback("odrv","errors",lambda v : self.showErrors(v),self.prefix,int)
         self.registerCallback("odrv","state",lambda v : self.stateCb(v),self.prefix,int)
@@ -104,7 +104,7 @@ class OdriveUI(WidgetUI,CommunicationHandler):
         torqueScaler = str(int(self.doubleSpinBox_torque.value() * 100))
         self.sendValue("odrv","canspd",spdPreset,instance=self.prefix)
         self.sendValue("odrv","canid",canId,instance=self.prefix)
-        self.sendValue("odrv","maxtorqe",torqueScaler,instance=self.prefix)
+        self.sendValue("odrv","maxtorque",torqueScaler,instance=self.prefix)
 
 
         self.initUi() # Update UI

--- a/pwmdriver_ui.py
+++ b/pwmdriver_ui.py
@@ -7,38 +7,47 @@ from helper import res_path,classlistToIds
 from PyQt5.QtCore import QTimer
 import main
 from base_ui import WidgetUI
+from base_ui import CommunicationHandler
 
-class PwmDriverUI(WidgetUI):
+class PwmDriverUI(WidgetUI,CommunicationHandler):
     
     def __init__(self, main=None, unique=1):
         WidgetUI.__init__(self, main,'pwmdriver_ui.ui')
+        CommunicationHandler.__init__(self)
         self.main = main #type: main.MainUi
-
-        self.initUi()
+        
         self.pushButton_apply.clicked.connect(self.apply)
 
+        self.registerCallback("pwmdrv","freq",self.freq_cb,0,str,typechar='!')
+        self.registerCallback("pwmdrv","freq",self.comboBox_freq.setCurrentIndex,0,int,typechar='?')
+
+        self.registerCallback("pwmdrv","mode",self.pwmmode_cb,0,str,typechar='!')
+        self.registerCallback("pwmdrv","mode",self.comboBox_mode.setCurrentIndex,0,int,typechar='?')
+
+        self.initUi()
+
     def initUi(self):
-        self.main.comms.serialGetAsync("pwm_mode!",self.pwmmode_cb)
-        self.main.comms.serialGetAsync("pwm_speed!",self.freq_cb)
+        # Fill menus
+        self.sendCommand("pwmdrv","freq",0,'!')
+        self.sendCommand("pwmdrv","mode",0,'!')
     
     def freq_cb(self,modes):
         self.comboBox_freq.clear()
         modes = [m.split(":") for m in modes.split("\n") if m]
         for m in modes:
             self.comboBox_freq.addItem(m[0],m[1])
-        self.main.comms.serialGetAsync("pwm_speed?",self.comboBox_freq.setCurrentIndex,int)
+        self.sendCommand("pwmdrv","freq",0,'?')
 
     def pwmmode_cb(self,modes):
         self.comboBox_mode.clear()
         modes = [m.split(":") for m in modes.split("\n") if m]
         for m in modes:
             self.comboBox_mode.addItem(m[0],m[1])
-        self.main.comms.serialGetAsync("pwm_mode?",self.comboBox_mode.setCurrentIndex,int)
+        self.sendCommand("pwmdrv","mode",0,'?')
 
  
     def apply(self):
-
-        self.main.comms.serialWrite("pwm_mode="+str(self.comboBox_mode.currentData()))
-        self.main.comms.serialWrite("pwm_speed="+str(self.comboBox_freq.currentData()))
+        self.sendValue("pwmdrv","mode",self.comboBox_mode.currentData())
+        self.sendValue("pwmdrv","freq",self.comboBox_freq.currentData())
         self.initUi() # Update UI
 

--- a/res/MainWindow.ui
+++ b/res/MainWindow.ui
@@ -76,6 +76,7 @@
      <string>Help</string>
     </property>
     <addaction name="actionErrors"/>
+    <addaction name="actionActive_features"/>
     <addaction name="actionAbout"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
@@ -122,8 +123,19 @@
    </property>
   </action>
   <action name="actionErrors">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Errors</string>
+   </property>
+  </action>
+  <action name="actionActive_features">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Active features</string>
    </property>
   </action>
  </widget>

--- a/res/activelist.ui
+++ b/res/activelist.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>605</width>
+    <height>370</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0" colspan="2">
+    <widget class="QTableView" name="tableView"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="pushButton_refresh">
+     <property name="text">
+      <string>Refresh</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/res/activelist.ui
+++ b/res/activelist.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>605</width>
-    <height>370</height>
+    <width>467</width>
+    <height>267</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,7 +21,32 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0" colspan="2">
-    <widget class="QTableView" name="tableView"/>
+    <widget class="QTableView" name="tableView">
+     <property name="minimumSize">
+      <size>
+       <width>400</width>
+       <height>200</height>
+      </size>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>40</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QPushButton" name="pushButton_refresh">

--- a/res/axis_ui.ui
+++ b/res/axis_ui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>886</width>
+    <width>847</width>
     <height>472</height>
    </rect>
   </property>
@@ -395,7 +395,7 @@
        <widget class="QGroupBox" name="groupBox_encoder">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
+          <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -411,7 +411,17 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QComboBox" name="comboBox_encoder"/>
+          <widget class="QComboBox" name="comboBox_encoder">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::AdjustToContents</enum>
+           </property>
+          </widget>
          </item>
          <item row="0" column="2">
           <widget class="QPushButton" name="pushButton_submit_enc">

--- a/res/ffbclass.ui
+++ b/res/ffbclass.ui
@@ -346,32 +346,6 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
-          <widget class="QSpinBox" name="spinBox_spring">
-           <property name="suffix">
-            <string/>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QSpinBox" name="spinBox_damper">
-           <property name="suffix">
-            <string/>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-          </widget>
-         </item>
          <item row="5" column="1">
           <widget class="QSlider" name="horizontalSlider_inertia">
            <property name="toolTip">
@@ -423,32 +397,6 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="QSpinBox" name="spinBox_friction">
-           <property name="suffix">
-            <string/>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2">
-          <widget class="QSpinBox" name="spinBox_inertia">
-           <property name="suffix">
-            <string/>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="maximum">
-            <number>255</number>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QSlider" name="horizontalSlider_CFq">
            <property name="minimum">
@@ -488,6 +436,49 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="2">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_spring">
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <double>4.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_damper">
+           <property name="maximum">
+            <double>2.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_friction">
+           <property name="maximum">
+            <double>2.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_inertia">
+           <property name="maximum">
+            <double>2.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -510,134 +501,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>horizontalSlider_inertia</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>spinBox_inertia</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>655</x>
-     <y>473</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>683</x>
-     <y>472</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spinBox_inertia</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>horizontalSlider_inertia</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>689</x>
-     <y>463</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>654</x>
-     <y>478</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>horizontalSlider_friction</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>spinBox_friction</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>607</x>
-     <y>439</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>676</x>
-     <y>438</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spinBox_friction</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>horizontalSlider_friction</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>671</x>
-     <y>446</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>653</x>
-     <y>448</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>horizontalSlider_damper</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>spinBox_damper</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>630</x>
-     <y>415</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>671</x>
-     <y>419</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spinBox_damper</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>horizontalSlider_damper</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>674</x>
-     <y>413</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>654</x>
-     <y>413</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>horizontalSlider_spring</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>spinBox_spring</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>634</x>
-     <y>384</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>672</x>
-     <y>391</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spinBox_spring</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>horizontalSlider_spring</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>675</x>
-     <y>383</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>648</x>
-     <y>379</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/res/tmc4671_ui.ui
+++ b/res/tmc4671_ui.ui
@@ -121,28 +121,14 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0" colspan="2">
+         <item row="4" column="0" colspan="2">
           <widget class="QPushButton" name="pushButton_align">
            <property name="text">
             <string>Align Encoder</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_11">
-           <property name="text">
-            <string>Motor current:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QLabel" name="label_Current">
-           <property name="text">
-            <string>0A</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
+         <item row="5" column="0" colspan="2">
           <widget class="Line" name="line_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -150,30 +136,58 @@
           </widget>
          </item>
          <item row="6" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Motor current:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLabel" name="label_Current">
+           <property name="text">
+            <string>0A</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
           <widget class="QLabel" name="label_12">
            <property name="text">
             <string>Temperature:</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="7" column="1">
           <widget class="QLabel" name="label_Temp">
            <property name="text">
             <string>0°C</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
             <string>Voltage:</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="8" column="1">
           <widget class="QLabel" name="label_volt">
            <property name="text">
             <string>0V</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QPushButton" name="pushButton_hwversion">
+           <property name="text">
+            <string>Select hardware version</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_hwversion">
+           <property name="text">
+            <string>HW Version</string>
            </property>
           </widget>
          </item>

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -39,10 +39,8 @@ class SerialComms(QObject):
 
     def removeCallbacks(handler):
         for cls,item in (SerialComms.callbackDict.items()):
-            for cb in (item):
-                if cb["handler"] == handler:
-                    #print("Remove callback",handler)
-                    item.remove(cb)
+            SerialComms.callbackDict[cls] = [ entry for entry in item if entry["handler"] != handler]
+
     def removeAllCallbacks(self):
         SerialComms.callbackDict.clear()
 

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -24,12 +24,8 @@ class SerialComms(QObject):
         QObject.__init__(self)
         self.serial = serialport
         self.main=main
-        #self.serialQueue = []
         self.serial.readyRead.connect(self.serialReceive)
-        #self.waitForRead = False
         self.serial.aboutToClose.connect(self.reset)
-        #self.cmdbuf = []
-        #self.persistentCallbacks = []
 
 
     def registerCallback(handler,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
@@ -47,7 +43,6 @@ class SerialComms(QObject):
                 if cb["handler"] == handler:
                     #print("Remove callback",handler)
                     item.remove(cb)
-        #print("CB",SerialComms.callbackDict)
     def removeAllCallbacks(self):
         SerialComms.callbackDict.clear()
 
@@ -74,10 +69,7 @@ class SerialComms(QObject):
 
     def reset(self):
         self.replytext = ""
-        # self.serialQueue.clear()
-        # self.waitForRead = False
-        # self.cmdbuf = []
-        
+
     def checkOk(self,reply):
         if(reply == "OK" or reply.find("Err") == -1):
             return
@@ -123,8 +115,7 @@ class SerialComms(QObject):
         typechar = groups[GRP_TYPE] if groups[GRP_TYPE] else ''
         cmd = groups[GRP_CMD]
         deleted = False
-        #if(typechar == '?'): # read command with value. return the value to the callback
-
+        
         if cls in SerialComms.callbackDict:
             for callbackObject in SerialComms.callbackDict[cls]:
                 if callbackObject["cmd"] != cmd:
@@ -133,6 +124,7 @@ class SerialComms(QObject):
                     #print("ignoring",callbackObject,instance)
                     continue
                 if typechar != callbackObject["typechar"] and callbackObject["typechar"] != None:
+                    #print("Ignoring",typechar,callbackObject["typechar"])
                     continue
                 if reply == "NOT_FOUND":
                     print(f"Cmd {cmd} not found. check syntax")
@@ -144,7 +136,5 @@ class SerialComms(QObject):
                     #print("Deleting",callbackObject)
                     SerialComms.callbackDict[cls].remove(callbackObject)
                     deleted = True
-   
-                
-                
+          
         return deleted

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -16,7 +16,7 @@ GRP_REPLY       = 6
 
 class SerialComms(QObject):
     replytext = ""
-    cmdRegex = re.compile(r"\[(\w+)\.(?:(\d+)\.)?(\w+)([?!=])(?:(\d+))?(?:\?(\d))?\|(.+)\]",re.DOTALL)
+    cmdRegex = re.compile(r"\[(\w+)\.(?:(\d+)\.)?(\w+)([?!=]?)(?:(\d+))?(?:\?(\d))?\|(.+)\]",re.DOTALL)
     callbackDict = {}
     rawReply = pyqtSignal(str)
 

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -3,24 +3,77 @@ from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication
 from collections import deque
 import re
+from PyQt5.QtCore import pyqtSignal
+
+# Regex group indices:
+GRP_CLS         = 0
+GRP_INSTANCE    = 1
+GRP_CMD         = 2
+GRP_TYPE        = 3
+GRP_CMDVAL1     = 4
+GRP_CMDVAL2     = 5
+GRP_REPLY       = 6
 
 class SerialComms(QObject):
     replytext = ""
+    cmdRegex = re.compile(r"\[(\w+)\.(?:(\d+)\.)?(\w+)([?!=])(?:(\d+))?(?:\?(\d))?\|(.+)\]",re.DOTALL)
+    callbackDict = {}
+    rawReply = pyqtSignal(str)
+
     def __init__(self,main,serialport):
         QObject.__init__(self)
         self.serial = serialport
         self.main=main
-        self.serialQueue = []
+        #self.serialQueue = []
         self.serial.readyRead.connect(self.serialReceive)
-        self.waitForRead = False
+        #self.waitForRead = False
         self.serial.aboutToClose.connect(self.reset)
-        self.cmdbuf = []
-        self.persistentCallbacks = []
+        #self.cmdbuf = []
+        #self.persistentCallbacks = []
+
+
+    def registerCallback(self,handler,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
+        if cls not in self.callbackDict:
+            self.callbackDict[cls] = []
+
+        callbackObj = {"handler":handler,"callback":callback,"convert":conversion,"instance":instance,"class":cls,"cmd":cmd,"address":adr,"delete":delete,"typechar":typechar}
+        if callbackObj not in self.callbackDict[cls]:
+            self.callbackDict[cls].append(callbackObj)
+            print("New callback",cls,cmd)
+
+    def removeCallbacks(self,handler):
+        for cls,item in (self.callbackDict.items()):
+            for cb in (item):
+                if cb["handler"] == handler:
+                    del cb
+        #print("CB",self.callbackDict)
+
+
+    def getValueAsync(self,handler,cls,cmd,callback,instance=0,conversion=None,adr=None,typechar='?',delete=True):
+        if typechar == None:
+            typechar = ''
+        self.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
+        self.serialWriteRaw(f"{cls}.{instance}.{cmd}{typechar};")
+
+    def sendCommand(self,cls,cmd,instance=0,typechar='?'):
+        cmdstring = f"{cls}.{instance}.{cmd}{typechar};"
+        self.serialWriteRaw(cmdstring)
+
+    def sendValue(self,handler,cls,cmd,val,adr=None,instance=0):
+        cmdstring  = f"{cls}.{instance}.{cmd}={val}"
+        if adr:
+            cmdstring+=str(adr)
+        cmdstring += ";"
+        self.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=self.checkOk,instance=instance,adr=adr,delete=True,typechar='=')
+        self.serialWriteRaw(cmdstring)
+
     
+
     def reset(self):
-        self.serialQueue.clear()
-        self.waitForRead = False
-        self.cmdbuf = []
+        self.replytext = ""
+        # self.serialQueue.clear()
+        # self.waitForRead = False
+        # self.cmdbuf = []
         
     def checkOk(self,reply):
         if(reply == "OK" or reply.find("Err") == -1):
@@ -28,176 +81,232 @@ class SerialComms(QObject):
         else:
             self.main.log(reply)
 
-    def serialWrite(self,cmd,prefix=None):
-        if(prefix != None):
-            cmd=prefix+"."+cmd
+    def serialWriteRaw(self,cmdraw):
         if(self.serial.isOpen()):
-            self.serialGetAsync(cmd,self.checkOk)
+            print(f"{cmdraw}")
+            self.serial.write(bytes(cmdraw,"utf-8"))
 
-    def setAsync(self,enabled):
-        try:
-            if(enabled):
-                self.serial.readyRead.connect(self.serialReceive)
-            else:
-                self.serial.readyRead.disconnect(self.serialReceive)
-        except:
-            pass
+    # def serialWrite(self,cmd,prefix=None):
+        
+    #     if(prefix != None):
+    #         cmd=prefix+"."+cmd
+    #     if(self.serial.isOpen()):
+    #         self.serialGetAsync(cmd,self.checkOk)
 
     def serialReceive(self):
-        if(self.waitForRead):
-            self.waitForRead=False
-            return
+        # if(self.waitForRead):
+        #     self.waitForRead=False
+        #     return
         data = self.serial.readAll()
         newReply = data.data().decode("utf-8")
         self.replytext += newReply # Buffer replies until newline found at end of buffer
-        if(self.replytext.endswith("\n")):
-            self.processReplies()
-
-    def processReplies(self):
-
-        text = self.replytext
-        self.replytext = ""
-
-        ################################
-        def process_cmd(entry):
-            for i,reply in enumerate(entry["replies"]):
-                if(entry["convert"]):
-                    entry["replies"][i] = entry["convert"](reply) #apply conversion
-            if(entry["callback"]):
-                if(len(entry["replies"]) == 1):
-                    entry["callback"](entry["replies"][0])
+        # if(self.replytext.endswith("\n")):
+        #     self.processReplies()
+        print(newReply)
+        while self.replytext:
+            firstEndmarker = self.replytext.find("]")
+            firstStartmarker = self.replytext.find("[")
+            if(firstStartmarker >= 0 and firstEndmarker > 1 and firstStartmarker < firstEndmarker):
+                self.rawReply.emit(self.replytext[firstStartmarker+1:firstEndmarker])
+                match = self.cmdRegex.search(self.replytext,firstStartmarker,firstEndmarker+1)
+                if (match):
+                    self.replytext = self.replytext[match.end()::] # cut out everything before the end of the match
+                    if self.processMatchedReply(match):
+                        pass
+                    else:
+                        pass
                 else:
-                    entry["callback"](entry["replies"])
+                    self.replytext = self.replytext[firstEndmarker+1::]
+            else:
+                break
 
-        ####################################
-        # Parse
+
+    def processMatchedReply(self,match):
+        groups = match.groups()
+        #print(groups)
+        cls = groups[GRP_CLS]
+        instance = int(groups[GRP_INSTANCE]) if groups[GRP_INSTANCE] else 0
+        reply = groups[GRP_REPLY]
+        typechar = groups[GRP_TYPE] if groups[GRP_TYPE] else ''
+        cmd = groups[GRP_CMD]
+        found = False
+        #if(typechar == '?'): # read command with value. return the value to the callback
+        if cls in self.callbackDict:
+            for i,callbackObject in enumerate(self.callbackDict[cls]):
+                if callbackObject["cmd"] != cmd:
+                    continue
+                if (instance != callbackObject["instance"]) and (callbackObject["instance"] != 0xff):
+                    print("ignoring",callbackObject,instance)
+                    continue
+                if typechar != callbackObject["typechar"] and callbackObject["typechar"] != None:
+                    continue
+                if(callbackObject["convert"]):
+                    reply = callbackObject["convert"](reply)
+                callbackObject["callback"](reply) # send reply to callback
+                #print("Got reply",reply)
+                if callbackObject["delete"]: # delete if flag is set
+                    del self.callbackDict[cls][i]
+                found = True
+        return found
+
+
+    ## REMOVE ALL BELOW'##########################################################################################################
+    # def setAsync(self,enabled):
+    #     try:
+    #         if(enabled):
+    #             self.serial.readyRead.connect(self.serialReceive)
+    #         else:
+    #             self.serial.readyRead.disconnect(self.serialReceive)
+    #     except:
+    #         pass
+
+
+    # def processReplies(self):
+
+    #     text = self.replytext
+    #     self.replytext = ""
+
+    #     ################################
+    #     def process_cmd(entry):
+    #         for i,reply in enumerate(entry["replies"]):
+    #             if(entry["convert"]):
+    #                 entry["replies"][i] = entry["convert"](reply) #apply conversion
+    #         if(entry["callback"]):
+    #             if(len(entry["replies"]) == 1):
+    #                 entry["callback"](entry["replies"][0])
+    #             else:
+    #                 entry["callback"](entry["replies"])
+
+    #     ####################################
+    #     # Parse
         
-        split_reply = text.split(">") #replies
+    #     split_reply = text.split(">") #replies
 
-        n = 0
-        # For all replies in buffer
-        for replytext in split_reply:
-            if replytext=="" or len(replytext) < 3:
-                continue
-            if(replytext[0] == "!"):
-                self.main.serialchooser.serialLog("Log: "+replytext[1::])
-                continue
-            reply = replytext.split(":",1)
-            if(len(reply) != 2):
-                #print(reply)
-                continue
-            cmd_reply = reply[0]
-            reply_val = reply[1]
+    #     n = 0
+    #     # For all replies in buffer
+    #     for replytext in split_reply:
+    #         if replytext=="" or len(replytext) < 3:
+    #             continue
+    #         if(replytext[0] == "!"):
+    #             self.main.serialchooser.serialLog("Log: "+replytext[1::])
+    #             continue
+    #         reply = replytext.split(":",1)
+    #         if(len(reply) != 2):
+    #             #print(reply)
+    #             continue
+    #         cmd_reply = reply[0]
+    #         reply_val = reply[1]
             
-            sendqueue_elem = None
-            # For all pending commands in queue (Should always be the first!)
-            for elem in enumerate(self.serialQueue):
-                try:
-                    cmdnames = elem[1]["cmds"]
-                    if(cmd_reply in cmdnames):
-                        sendqueue_elem = elem[1]
-                        sendqueue_elem["replies"].append(reply_val)
-                        sendqueue_elem["cmds"].remove(cmd_reply) # reply found. remove cmd so this entry is not found for additional replies of the same name if slow
-                        if not (len(sendqueue_elem["replies"]) < sendqueue_elem["len"]):
-                            # finished with all commands?
-                            process_cmd(sendqueue_elem)
-                            del self.serialQueue[elem[0]] # delete only when all replies received and not persistent entry
-                        break
-                except Exception as e:
+    #         sendqueue_elem = None
+    #         # For all pending commands in queue (Should always be the first!)
+    #         for elem in enumerate(self.serialQueue):
+    #             try:
+    #                 cmdnames = elem[1]["cmds"]
+    #                 if(cmd_reply in cmdnames):
+    #                     sendqueue_elem = elem[1]
+    #                     sendqueue_elem["replies"].append(reply_val)
+    #                     sendqueue_elem["cmds"].remove(cmd_reply) # reply found. remove cmd so this entry is not found for additional replies of the same name if slow
+    #                     if not (len(sendqueue_elem["replies"]) < sendqueue_elem["len"]):
+    #                         # finished with all commands?
+    #                         process_cmd(sendqueue_elem)
+    #                         del self.serialQueue[elem[0]] # delete only when all replies received and not persistent entry
+    #                     break
+    #             except Exception as e:
                   
-                    raise e
+    #                 raise e
                     
-                    self.main.serialchooser.serialLog("Error while processing reply {}.\nError:{}\n".format(cmd_reply,e))
+    #                 self.main.serialchooser.serialLog("Error while processing reply {}.\nError:{}\n".format(cmd_reply,e))
 
             
-            # Persistent callbacks
-            for elem in self.persistentCallbacks:
-                cmdnames = elem["cmds"]
-                if(cmd_reply in cmdnames):
-                    elem["replies"].append(reply_val)
-                    process_cmd(elem)
-                    elem["replies"].clear()
+    #         # Persistent callbacks
+    #         for elem in self.persistentCallbacks:
+    #             cmdnames = elem["cmds"]
+    #             if(cmd_reply in cmdnames):
+    #                 elem["replies"].append(reply_val)
+    #                 process_cmd(elem)
+    #                 elem["replies"].clear()
 
-            if(sendqueue_elem == None):
-                # Nothing found. Received a command nobody waits on.
-                self.main.serialchooser.serialLog(replytext+"\n")
+    #         if(sendqueue_elem == None):
+    #             # Nothing found. Received a command nobody waits on.
+    #             self.main.serialchooser.serialLog(replytext+"\n")
 
         
-    # Adds command to send and receive queue
-    def addToQueue(self,cmdraw,callback,convert):
-        if(not cmdraw.endswith(";") and not cmdraw.endswith("\n")):
-            cmdraw = cmdraw+";"
-        # try to split command names
-        cmds = [c for c in re.split(';|\n',cmdraw) if c]
-        entry = {"callback":callback,"cmdraw":cmdraw,"cmds":cmds,"convert":convert,"replies":[],"len":len(cmds)}
+    # # Adds command to send and receive queue
+    # def addToQueue(self,cmdraw,callback,convert):
+    #     if(not cmdraw.endswith(";") and not cmdraw.endswith("\n")):
+    #         cmdraw = cmdraw+";"
+    #     # try to split command names
+    #     cmds = [c for c in re.split(';|\n',cmdraw) if c]
+    #     entry = {"callback":callback,"cmdraw":cmdraw,"cmds":cmds,"convert":convert,"replies":[],"len":len(cmds)}
 
-        # check if exactly the same request is already present to prevent flooding if serial port is frozen
-        if entry in self.serialQueue:
-            return
+    #     # check if exactly the same request is already present to prevent flooding if serial port is frozen
+    #     if entry in self.serialQueue:
+    #         return
 
-        self.serialQueue.append(entry)
+    #     self.serialQueue.append(entry)
 
-        self.serial.write(bytes(cmdraw,"utf-8"))
+    #     self.serial.write(bytes(cmdraw,"utf-8"))
 
-    """
-     Get asynchronous commands and pass the result to the callback. 
-     Better performance. Recommended
-     cmds and callbacks can be lists or a single command (without ; or \n)
-     Usages:
-     pass multiple commands in a list with a single callback (Will pass a list of replies)
-     pass a single command and a single callback
-     pass multiple commands and callbacks in lists
-     You can also pass an additional conversion function to apply to all replies before sending to callbacks. (int or float for example)
-    """
-    def serialGetAsync(self,cmds,callbacks,convert=None,prefix=None):
-        if(prefix != None):
-            if(type(cmds) == list):
-                for i in range(len(cmds)):
-                    cmds[i]=prefix+"."+cmds[i]
-            elif (type(cmds) == str):
-                cmds=prefix+"."+cmds
-        if(not self.serial.isOpen()):
-            return False
-        if(type(cmds) == list and type(callbacks) == list): # Multiple commands and callbacks
-            for cmd,callback in zip(cmds,callbacks):
-                self.addToQueue(cmd,callback,convert)
-        elif(type(cmds) == list): # Multiple commands. One callback
-            #for cmd in cmds:
-            cmd = ";".join(cmds)
-            self.addToQueue(cmd,callbacks,convert)
-        else: # One command and callback or direct
-            self.addToQueue(cmds,callbacks,convert)
+    # """
+    #  Get asynchronous commands and pass the result to the callback. 
+    #  Better performance. Recommended
+    #  cmds and callbacks can be lists or a single command (without ; or \n)
+    #  Usages:
+    #  pass multiple commands in a list with a single callback (Will pass a list of replies)
+    #  pass a single command and a single callback
+    #  pass multiple commands and callbacks in lists
+    #  You can also pass an additional conversion function to apply to all replies before sending to callbacks. (int or float for example)
+    # """
+    # def serialGetAsync(self,cmds,callbacks,convert=None,prefix=None):
+    #     print("oldCMD:",cmds)
+    #     if(prefix != None):
+    #         if(type(cmds) == list):
+    #             for i in range(len(cmds)):
+    #                 cmds[i]=prefix+"."+cmds[i]
+    #         elif (type(cmds) == str):
+    #             cmds=prefix+"."+cmds
+    #     if(not self.serial.isOpen()):
+    #         return False
+    #     if(type(cmds) == list and type(callbacks) == list): # Multiple commands and callbacks
+    #         for cmd,callback in zip(cmds,callbacks):
+    #             self.addToQueue(cmd,callback,convert)
+    #     elif(type(cmds) == list): # Multiple commands. One callback
+    #         #for cmd in cmds:
+    #         cmd = ";".join(cmds)
+    #         self.addToQueue(cmd,callbacks,convert)
+    #     else: # One command and callback or direct
+    #         self.addToQueue(cmds,callbacks,convert)
 
-    def serialRegisterCallback(self,cmd,callback,convert = None):
-        self.persistentCallbacks.append({"callback":callback,"cmdraw":cmd,"cmds":[cmd],"convert":convert,"replies":[],"len":1})
+    # def serialRegisterCallback(self,cmd,callback,convert = None):
+    #     self.persistentCallbacks.append({"callback":callback,"cmdraw":cmd,"cmds":[cmd],"convert":convert,"replies":[],"len":1})
 
-    # get a synchronous reply with timeout. Not recommended
-    def serialGet(self,cmd,timeout=500):
-        if(not self.serial.isOpen()):
-            self.main.log("Error: Serial closed")
-            return None
-        t=0
+    # # get a synchronous reply with timeout. Not recommended
+    # def serialGet(self,cmd,timeout=500):
+    #     if(not self.serial.isOpen()):
+    #         self.main.log("Error: Serial closed")
+    #         return None
+    #     t=0
 
-        self.waitForRead = True
-        self.serial.write(bytes(cmd,"utf-8"))
-        t=0
-        while self.waitForRead:
-            if(timeout-t < 0):
-                return None
-            t+=10
-            time.sleep(0.01)
-            QApplication.processEvents()
+    #     self.waitForRead = True
+    #     self.serial.write(bytes(cmd,"utf-8"))
+    #     t=0
+    #     while self.waitForRead:
+    #         if(timeout-t < 0):
+    #             return None
+    #         t+=10
+    #         time.sleep(0.01)
+    #         QApplication.processEvents()
 
-        data = self.serial.readAll()
+    #     data = self.serial.readAll()
 
-        lastSerial = data.data().decode("utf-8")
-        reply = lastSerial[1::].split(":",1)
-        checkcmd = re.split(';|\n',cmd)[0]
-        if(checkcmd != reply[0]):
-            print("Error. incorrect reply received " + reply[0] + " expected " + checkcmd)
-            return None
-        lastSerial=reply[1]
+    #     lastSerial = data.data().decode("utf-8")
+    #     reply = lastSerial[1::].split(":",1)
+    #     checkcmd = re.split(';|\n',cmd)[0]
+    #     if(checkcmd != reply[0]):
+    #         print("Error. incorrect reply received " + reply[0] + " expected " + checkcmd)
+    #         return None
+    #     lastSerial=reply[1]
  
-        if(lastSerial and lastSerial[-1] == "\n"):
-            lastSerial=lastSerial[0:-1]
-        return lastSerial
+    #     if(lastSerial and lastSerial[-1] == "\n"):
+    #         lastSerial=lastSerial[0:-1]
+    #     return lastSerial

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -32,27 +32,30 @@ class SerialComms(QObject):
         #self.persistentCallbacks = []
 
 
-    def registerCallback(self,handler,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
-        if cls not in self.callbackDict:
-            self.callbackDict[cls] = []
+    def registerCallback(handler,cls,cmd,callback,instance=0,conversion=None,adr=None,delete=False,typechar='?'):
+        if cls not in SerialComms.callbackDict:
+            SerialComms.callbackDict[cls] = []
 
         callbackObj = {"handler":handler,"callback":callback,"convert":conversion,"instance":instance,"class":cls,"cmd":cmd,"address":adr,"delete":delete,"typechar":typechar}
-        if callbackObj not in self.callbackDict[cls]:
-            self.callbackDict[cls].append(callbackObj)
-            print("New callback",cls,cmd)
+        if callbackObj not in SerialComms.callbackDict[cls]:
+            SerialComms.callbackDict[cls].append(callbackObj)
+            #print("New callback",cls,cmd)
 
-    def removeCallbacks(self,handler):
-        for cls,item in (self.callbackDict.items()):
+    def removeCallbacks(handler):
+        for cls,item in (SerialComms.callbackDict.items()):
             for cb in (item):
                 if cb["handler"] == handler:
-                    del cb
-        #print("CB",self.callbackDict)
+                    #print("Remove callback",handler)
+                    item.remove(cb)
+        #print("CB",SerialComms.callbackDict)
+    def removeAllCallbacks(self):
+        SerialComms.callbackDict.clear()
 
 
     def getValueAsync(self,handler,cls,cmd,callback,instance=0,conversion=None,adr=None,typechar='?',delete=True):
         if typechar == None:
             typechar = ''
-        self.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
+        SerialComms.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=callback,instance=instance,conversion=conversion,adr=adr,delete=delete,typechar=typechar)
         self.serialWriteRaw(f"{cls}.{instance}.{cmd}{typechar};")
 
     def sendCommand(self,cls,cmd,instance=0,typechar='?'):
@@ -64,7 +67,7 @@ class SerialComms(QObject):
         if adr:
             cmdstring+=str(adr)
         cmdstring += ";"
-        self.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=self.checkOk,instance=instance,adr=adr,delete=True,typechar='=')
+        SerialComms.registerCallback(handler=handler,cls=cls,cmd=cmd,callback=self.checkOk,instance=instance,adr=adr,delete=True,typechar='=')
         self.serialWriteRaw(cmdstring)
 
     
@@ -83,39 +86,29 @@ class SerialComms(QObject):
 
     def serialWriteRaw(self,cmdraw):
         if(self.serial.isOpen()):
-            print(f"{cmdraw}")
+            #print(f"{cmdraw}")
             self.serial.write(bytes(cmdraw,"utf-8"))
 
-    # def serialWrite(self,cmd,prefix=None):
-        
-    #     if(prefix != None):
-    #         cmd=prefix+"."+cmd
-    #     if(self.serial.isOpen()):
-    #         self.serialGetAsync(cmd,self.checkOk)
-
     def serialReceive(self):
-        # if(self.waitForRead):
-        #     self.waitForRead=False
-        #     return
         data = self.serial.readAll()
         newReply = data.data().decode("utf-8")
         self.replytext += newReply # Buffer replies until newline found at end of buffer
-        # if(self.replytext.endswith("\n")):
-        #     self.processReplies()
-        print(newReply)
+    
         while self.replytext:
             firstEndmarker = self.replytext.find("]")
             firstStartmarker = self.replytext.find("[")
             if(firstStartmarker >= 0 and firstEndmarker > 1 and firstStartmarker < firstEndmarker):
-                self.rawReply.emit(self.replytext[firstStartmarker+1:firstEndmarker])
                 match = self.cmdRegex.search(self.replytext,firstStartmarker,firstEndmarker+1)
                 if (match):
+                    curRepl = self.replytext[firstStartmarker+1:firstEndmarker]
                     self.replytext = self.replytext[match.end()::] # cut out everything before the end of the match
                     if self.processMatchedReply(match):
                         pass
                     else:
-                        pass
+                        self.rawReply.emit(curRepl)
+                    
                 else:
+                    self.rawReply.emit(self.replytext[firstStartmarker+1:firstEndmarker])
                     self.replytext = self.replytext[firstEndmarker+1::]
             else:
                 break
@@ -126,187 +119,32 @@ class SerialComms(QObject):
         #print(groups)
         cls = groups[GRP_CLS]
         instance = int(groups[GRP_INSTANCE]) if groups[GRP_INSTANCE] else 0
-        reply = groups[GRP_REPLY]
+        reply = str(groups[GRP_REPLY])
         typechar = groups[GRP_TYPE] if groups[GRP_TYPE] else ''
         cmd = groups[GRP_CMD]
-        found = False
+        deleted = False
         #if(typechar == '?'): # read command with value. return the value to the callback
-        if cls in self.callbackDict:
-            for i,callbackObject in enumerate(self.callbackDict[cls]):
+
+        if cls in SerialComms.callbackDict:
+            for callbackObject in SerialComms.callbackDict[cls]:
                 if callbackObject["cmd"] != cmd:
                     continue
                 if (instance != callbackObject["instance"]) and (callbackObject["instance"] != 0xff):
-                    print("ignoring",callbackObject,instance)
+                    #print("ignoring",callbackObject,instance)
                     continue
                 if typechar != callbackObject["typechar"] and callbackObject["typechar"] != None:
                     continue
+                if reply == "NOT_FOUND":
+                    print(f"Cmd {cmd} not found. check syntax")
+                    continue
                 if(callbackObject["convert"]):
                     reply = callbackObject["convert"](reply)
-                callbackObject["callback"](reply) # send reply to callback
-                #print("Got reply",reply)
+                callbackObject["callback"](reply) 
                 if callbackObject["delete"]: # delete if flag is set
-                    del self.callbackDict[cls][i]
-                found = True
-        return found
-
-
-    ## REMOVE ALL BELOW'##########################################################################################################
-    # def setAsync(self,enabled):
-    #     try:
-    #         if(enabled):
-    #             self.serial.readyRead.connect(self.serialReceive)
-    #         else:
-    #             self.serial.readyRead.disconnect(self.serialReceive)
-    #     except:
-    #         pass
-
-
-    # def processReplies(self):
-
-    #     text = self.replytext
-    #     self.replytext = ""
-
-    #     ################################
-    #     def process_cmd(entry):
-    #         for i,reply in enumerate(entry["replies"]):
-    #             if(entry["convert"]):
-    #                 entry["replies"][i] = entry["convert"](reply) #apply conversion
-    #         if(entry["callback"]):
-    #             if(len(entry["replies"]) == 1):
-    #                 entry["callback"](entry["replies"][0])
-    #             else:
-    #                 entry["callback"](entry["replies"])
-
-    #     ####################################
-    #     # Parse
-        
-    #     split_reply = text.split(">") #replies
-
-    #     n = 0
-    #     # For all replies in buffer
-    #     for replytext in split_reply:
-    #         if replytext=="" or len(replytext) < 3:
-    #             continue
-    #         if(replytext[0] == "!"):
-    #             self.main.serialchooser.serialLog("Log: "+replytext[1::])
-    #             continue
-    #         reply = replytext.split(":",1)
-    #         if(len(reply) != 2):
-    #             #print(reply)
-    #             continue
-    #         cmd_reply = reply[0]
-    #         reply_val = reply[1]
-            
-    #         sendqueue_elem = None
-    #         # For all pending commands in queue (Should always be the first!)
-    #         for elem in enumerate(self.serialQueue):
-    #             try:
-    #                 cmdnames = elem[1]["cmds"]
-    #                 if(cmd_reply in cmdnames):
-    #                     sendqueue_elem = elem[1]
-    #                     sendqueue_elem["replies"].append(reply_val)
-    #                     sendqueue_elem["cmds"].remove(cmd_reply) # reply found. remove cmd so this entry is not found for additional replies of the same name if slow
-    #                     if not (len(sendqueue_elem["replies"]) < sendqueue_elem["len"]):
-    #                         # finished with all commands?
-    #                         process_cmd(sendqueue_elem)
-    #                         del self.serialQueue[elem[0]] # delete only when all replies received and not persistent entry
-    #                     break
-    #             except Exception as e:
-                  
-    #                 raise e
-                    
-    #                 self.main.serialchooser.serialLog("Error while processing reply {}.\nError:{}\n".format(cmd_reply,e))
-
-            
-    #         # Persistent callbacks
-    #         for elem in self.persistentCallbacks:
-    #             cmdnames = elem["cmds"]
-    #             if(cmd_reply in cmdnames):
-    #                 elem["replies"].append(reply_val)
-    #                 process_cmd(elem)
-    #                 elem["replies"].clear()
-
-    #         if(sendqueue_elem == None):
-    #             # Nothing found. Received a command nobody waits on.
-    #             self.main.serialchooser.serialLog(replytext+"\n")
-
-        
-    # # Adds command to send and receive queue
-    # def addToQueue(self,cmdraw,callback,convert):
-    #     if(not cmdraw.endswith(";") and not cmdraw.endswith("\n")):
-    #         cmdraw = cmdraw+";"
-    #     # try to split command names
-    #     cmds = [c for c in re.split(';|\n',cmdraw) if c]
-    #     entry = {"callback":callback,"cmdraw":cmdraw,"cmds":cmds,"convert":convert,"replies":[],"len":len(cmds)}
-
-    #     # check if exactly the same request is already present to prevent flooding if serial port is frozen
-    #     if entry in self.serialQueue:
-    #         return
-
-    #     self.serialQueue.append(entry)
-
-    #     self.serial.write(bytes(cmdraw,"utf-8"))
-
-    # """
-    #  Get asynchronous commands and pass the result to the callback. 
-    #  Better performance. Recommended
-    #  cmds and callbacks can be lists or a single command (without ; or \n)
-    #  Usages:
-    #  pass multiple commands in a list with a single callback (Will pass a list of replies)
-    #  pass a single command and a single callback
-    #  pass multiple commands and callbacks in lists
-    #  You can also pass an additional conversion function to apply to all replies before sending to callbacks. (int or float for example)
-    # """
-    # def serialGetAsync(self,cmds,callbacks,convert=None,prefix=None):
-    #     print("oldCMD:",cmds)
-    #     if(prefix != None):
-    #         if(type(cmds) == list):
-    #             for i in range(len(cmds)):
-    #                 cmds[i]=prefix+"."+cmds[i]
-    #         elif (type(cmds) == str):
-    #             cmds=prefix+"."+cmds
-    #     if(not self.serial.isOpen()):
-    #         return False
-    #     if(type(cmds) == list and type(callbacks) == list): # Multiple commands and callbacks
-    #         for cmd,callback in zip(cmds,callbacks):
-    #             self.addToQueue(cmd,callback,convert)
-    #     elif(type(cmds) == list): # Multiple commands. One callback
-    #         #for cmd in cmds:
-    #         cmd = ";".join(cmds)
-    #         self.addToQueue(cmd,callbacks,convert)
-    #     else: # One command and callback or direct
-    #         self.addToQueue(cmds,callbacks,convert)
-
-    # def serialRegisterCallback(self,cmd,callback,convert = None):
-    #     self.persistentCallbacks.append({"callback":callback,"cmdraw":cmd,"cmds":[cmd],"convert":convert,"replies":[],"len":1})
-
-    # # get a synchronous reply with timeout. Not recommended
-    # def serialGet(self,cmd,timeout=500):
-    #     if(not self.serial.isOpen()):
-    #         self.main.log("Error: Serial closed")
-    #         return None
-    #     t=0
-
-    #     self.waitForRead = True
-    #     self.serial.write(bytes(cmd,"utf-8"))
-    #     t=0
-    #     while self.waitForRead:
-    #         if(timeout-t < 0):
-    #             return None
-    #         t+=10
-    #         time.sleep(0.01)
-    #         QApplication.processEvents()
-
-    #     data = self.serial.readAll()
-
-    #     lastSerial = data.data().decode("utf-8")
-    #     reply = lastSerial[1::].split(":",1)
-    #     checkcmd = re.split(';|\n',cmd)[0]
-    #     if(checkcmd != reply[0]):
-    #         print("Error. incorrect reply received " + reply[0] + " expected " + checkcmd)
-    #         return None
-    #     lastSerial=reply[1]
- 
-    #     if(lastSerial and lastSerial[-1] == "\n"):
-    #         lastSerial=lastSerial[0:-1]
-    #     return lastSerial
+                    #print("Deleting",callbackObject)
+                    SerialComms.callbackDict[cls].remove(callbackObject)
+                    deleted = True
+   
+                
+                
+        return deleted

--- a/serial_ui.py
+++ b/serial_ui.py
@@ -133,7 +133,7 @@ class SerialChooser(WidgetUI,CommunicationHandler):
 
     def mainBtn(self):
         id = self.classes[self.comboBox_main.currentIndex()][0]
-        self.main.comms.serialWrite("main="+str(id)+"\n")
+        self.sendValue("sys","main",id)
         self.main.reconnect()
         msg = QMessageBox(QMessageBox.Information,"Main class changed","Chip is rebooting. Please reconnect.")
         msg.exec_()

--- a/serial_ui.py
+++ b/serial_ui.py
@@ -81,7 +81,7 @@ class SerialChooser(WidgetUI,CommunicationHandler):
         if(not self.serial.isOpen() and self.port != None):
             self.main.log("Connecting...")
             self.serial.setPort(self.port)
-            self.serial.setBaudRate(115200)
+            self.serial.setBaudRate(500000)
             self.serial.open(QIODevice.ReadWrite)
         else:
             self.serial.close()

--- a/serial_ui.py
+++ b/serial_ui.py
@@ -83,6 +83,8 @@ class SerialChooser(WidgetUI,CommunicationHandler):
             self.serial.setPort(self.port)
             self.serial.setBaudRate(500000)
             self.serial.open(QIODevice.ReadWrite)
+            if(not self.serial.isOpen()):
+                self.main.log("Can not open port")
         else:
             self.serial.close()
             

--- a/system_ui.py
+++ b/system_ui.py
@@ -20,11 +20,18 @@ class SystemUI(WidgetUI,CommunicationHandler):
         self.pushButton_save.clicked.connect(self.saveClicked)
 
     def updateRamUse(self,reply):
-        #use,size = re.match(r"Usage:\W(\d+)\WSize:\W(\d+)",reply).groups()
-        use = int(reply)
+        usage = reply.split(":")
+        use = int(usage[0])
+        minuse = None
+        if(len(usage) == 2):
+            minuse = int(usage[1])
         if use:
             use = round(int(use)/1000.0,2)
-            self.label_ramUse.setText("{}k".format(use))
+            if minuse:
+                minuse = round(int(minuse)/1000.0,2)
+                self.label_ramUse.setText("{}k ({}k min)".format(use,minuse))
+            else:
+                self.label_ramUse.setText("{}k".format(use))
 
     def saveClicked(self):
         def f(res):

--- a/system_ui.py
+++ b/system_ui.py
@@ -28,18 +28,18 @@ class SystemUI(WidgetUI):
     def saveClicked(self):
         def f(res):
             self.main.log("Save: "+ str(res))
-        self.main.comms.serialGetAsync("save\n",f)
+        self.main.comms.getValueAsync("sys","save",callback=f)
         
     def setSaveBtn(self,on):
         self.pushButton_save.setEnabled(on)
 
 
     def reboot(self):
-        self.main.comms.serialWrite("reboot\n")
+        self.main.comms.sendCommand("sys","reboot")
         self.main.reconnect()
     
     def dfu(self):
-        self.main.comms.serialWrite("dfu\n")
+        self.main.comms.sendCommand("sys","dfu")
         self.main.log("Entering DFU...")
         self.main.resetPort()
         self.main.dfuUploader()
@@ -47,8 +47,8 @@ class SystemUI(WidgetUI):
     def factoryReset(self, btn):
         cmd = btn.text()
         if(cmd=="OK"):
-            self.main.comms.serialWrite("format=1\n")
-            self.main.comms.serialWrite("reboot\n")
+            self.main.comms.sendValue("sys","format",1)
+            self.main.comms.sendCommand("sys","reboot")
             self.main.resetPort()
 
     def factoryResetBtn(self):

--- a/system_ui.py
+++ b/system_ui.py
@@ -3,15 +3,16 @@ from PyQt5.QtWidgets import QWidget,QDialog,QVBoxLayout,QMessageBox
 from PyQt5 import uic
 from helper import res_path
 from PyQt5.QtCore import QTimer
-from base_ui import WidgetUI
+from base_ui import WidgetUI,CommunicationHandler
 import re
 
-class SystemUI(WidgetUI):
+class SystemUI(WidgetUI,CommunicationHandler):
     
     mainID = None
     def __init__(self, main=None):
 
         WidgetUI.__init__(self, main,'baseclass.ui')
+        CommunicationHandler.__init__(self)
         self.setEnabled(False)
         self.pushButton_reboot.clicked.connect(self.reboot)
         self.pushButton_dfu.clicked.connect(self.dfu)
@@ -28,18 +29,18 @@ class SystemUI(WidgetUI):
     def saveClicked(self):
         def f(res):
             self.main.log("Save: "+ str(res))
-        self.main.comms.getValueAsync("sys","save",callback=f)
+        self.getValueAsync("sys","save",callback=f)
         
     def setSaveBtn(self,on):
         self.pushButton_save.setEnabled(on)
 
 
     def reboot(self):
-        self.main.comms.sendCommand("sys","reboot")
+        self.sendCommand("sys","reboot")
         self.main.reconnect()
     
     def dfu(self):
-        self.main.comms.sendCommand("sys","dfu")
+        self.sendCommand("sys","dfu")
         self.main.log("Entering DFU...")
         self.main.resetPort()
         self.main.dfuUploader()
@@ -47,8 +48,8 @@ class SystemUI(WidgetUI):
     def factoryReset(self, btn):
         cmd = btn.text()
         if(cmd=="OK"):
-            self.main.comms.sendValue("sys","format",1)
-            self.main.comms.sendCommand("sys","reboot")
+            self.sendValue("sys","format",1)
+            self.sendCommand("sys","reboot")
             self.main.resetPort()
 
     def factoryResetBtn(self):

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -139,7 +139,6 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         
         
     def updateStatus(self):
-        #self.serialGetAsync("tmctemp",self.updateTemp,float)
         self.sendCommand("tmc","temp",self.axis)
         self.sendCommands("sys",["vint","vext"])
 
@@ -158,11 +157,9 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
     def submitPid(self):
         # PIDs
         seq = 1 if self.checkBox_advancedpid.isChecked() else 0
-        #self.serialWrite("seqpi="+str(seq))
         self.sendValue("tmc","seqpi",val=seq,instance=self.axis)
 
         tp = self.spinBox_tp.value()
-        #self.serialWrite("torqueP="+str(tp))
         self.sendValue("tmc","torqueP",val=tp,instance=self.axis)
 
         ti = self.spinBox_ti.value()
@@ -200,7 +197,6 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         self.checkBox_I_Precision.setEnabled(state)
         if(state):
             pass
-            #self.serialGetAsync("pidPrec?",self.precisionCb,int) #update checkbox
         else:
             self.checkBox_P_Precision.setChecked(False)
             self.checkBox_I_Precision.setChecked(False)
@@ -210,8 +206,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         selectorPopup.exec()
         self.sendCommand("tmc","tmcHwType",self.axis,'!')
         self.sendCommand("tmc","tmcHwType",self.axis,'?')
-        #self.serialGetAsync(["tmcHwType?","tmcHwType!"],self.hwtcb)
-    
+       
     def hwVersionsCb(self,v):
         entriesList = v.split("\n")
         entriesList = [m.split(":") for m in entriesList if m]
@@ -233,15 +228,10 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         try:
             # Fill encoder source types
             self.comboBox_enc.clear()
- 
-            #self.serialGetAsync("encsrc!",encs)
             self.sendCommands("tmc",["encsrc","tmcHwType"],self.axis,'!')
             self.sendCommands("tmc",["tmctype","tmcHwType","tmcIscale"],self.axis)
-            #self.serialGetAsync("tmctype",self.groupBox_tmc.setTitle)  
             self.getMotor()
             self.getPids()
-            #self.serialGetAsync(["tmcHwType?","tmcHwType!"],self.hwtcb)
-            #self.serialGetAsync("tmcIscale?",self.setCurrentScaler,convert=float)
 
             self.spinBox_fluxoffset.valueChanged.connect(lambda v : self.sendValue("tmc","fluxoffset",v,instance=self.axis))
             self.pushButton_submitmotor.clicked.connect(self.submitMotor)
@@ -264,7 +254,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
                 msg = QMessageBox(QMessageBox.Information,"Encoder align",res)
                 msg.exec_()
 
-        res = self.getValueAsync("tmc","encalign",f,self.axis)
+        res = self.getValueAsync("tmc","encalign",f,self.axis,typechar='?')
         self.main.log("Started encoder alignment")
         
 
@@ -275,7 +265,6 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
 
     def getPids(self):
         commands = ["pidPrec","torqueP","torqueI","fluxP","fluxI","fluxoffset","seqpi"]
-        #self.serialGetAsync(commands,callbacks,convert=int)
         self.sendCommands("tmc",commands,self.axis)
 
         
@@ -284,20 +273,6 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         if(x != self.adc_to_amps):
             self.curveAmpData.clear()
         self.adc_to_amps = x
-
-    # def serialWrite(self,cmd):
-    #     cmd = self.axis+"."+cmd
-    #     self.main.comms.serialWrite(cmd)
-
-
-    # def serialGetAsync(self,cmds,callbacks,convert=None):
-    #     if(type(cmds) == list):
-    #         axis_cmds = list(map(lambda x: self.axis+"."+x, cmds)) # y.torqueP? etc
-    #     else:
-    #         axis_cmds = self.axis+"."+cmds
-    #     self.main.comms.serialGetAsync(axis_cmds,callbacks,convert)
-
-
 
 class TMC_HW_Version_Selector(OptionsDialogGroupBox,CommunicationHandler):
 

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -72,7 +72,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         self.registerCallback("tmc","mtype",self.comboBox_mtype.setCurrentIndex,self.axis,int)
         self.registerCallback("tmc","poles",self.spinBox_poles.setValue,self.axis,int)
         self.registerCallback("tmc","encsrc",self.comboBox_enc.setCurrentIndex,self.axis,int)
-        self.registerCallback("tmc","cprtmc",self.spinBox_cpr.setValue,self.axis,int)
+        self.registerCallback("tmc","cpr",self.spinBox_cpr.setValue,self.axis,int)
 
         self.registerCallback("tmc","iScale",self.setCurrentScaler,self.axis,float)
 
@@ -259,7 +259,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         
 
     def getMotor(self):
-        commands=["mtype","poles","encsrc","cprtmc"]
+        commands=["mtype","poles","encsrc","cpr"]
         self.sendCommands("tmc",commands,self.axis)
 
 

--- a/vesc_ui.py
+++ b/vesc_ui.py
@@ -8,15 +8,17 @@ from PyQt5.QtCore import QTimer
 import main
 from base_ui import WidgetUI
 import math
+from base_ui import CommunicationHandler
 
-class VescUI(WidgetUI):
+class VescUI(WidgetUI,CommunicationHandler):
     prefix = None
     odriveStates = ["AXIS_STATE_UNDEFINED","AXIS_STATE_IDLE","AXIS_STATE_STARTUP_SEQUENCE","AXIS_STATE_FULL_CALIBRATION_SEQUENCE","AXIS_STATE_MOTOR_CALIBRATION","-","AXIS_STATE_ENCODER_INDEX_SEARCH","AXIS_STATE_ENCODER_OFFSET_CALIBRATION","AXIS_STATE_CLOSED_LOOP_CONTROL","AXIS_STATE_LOCKIN_SPIN","AXIS_STATE_ENCODER_DIR_FIND","AXIS_STATE_HOMING","AXIS_STATE_ENCODER_HALL_POLARITY_CALIBRATION","AXIS_STATE_ENCODER_HALL_PHASE_CALIBRATION"]
     def __init__(self, main=None, unique=None):
         WidgetUI.__init__(self, main,'vesc.ui')
+        CommunicationHandler.__init__(self)
         self.main = main #type: main.MainUi
         self.timer = QTimer(self)
-        self.initUi()
+        
         self.pushButton_apply.clicked.connect(self.apply)
         self.pushButton_manualRead.clicked.connect(self.manualEncPosRead)
         self.pushButton_eraseOffset.clicked.connect(self.eraseOffset)
@@ -24,8 +26,20 @@ class VescUI(WidgetUI):
         self.timer.timeout.connect(self.updateTimer)
         self.prefix = unique
 
-        self.checkBox_useEncoder.stateChanged.connect(lambda val : self.main.comms.serialWrite("vescUseEncoder="+("0" if val == 0 else "1")+"\n"))
+        self.checkBox_useEncoder.stateChanged.connect(lambda val : self.sendValue("vesc","useencoder",(0 if val == 0 else 1),instance=self.prefix))
+        self.registerCallback("vesc","canid",self.spinBox_id.setValue,self.axis,int)
+        self.registerCallback("vesc","canspd",self.updateCanSpd,self.axis,int)
+        self.registerCallback("vesc","useencoder",self.updateEncoderUI,self.axis,int)
+        self.registerCallback("vesc","offset",self.updateOffset,self.axis,int)
 
+        self.registerCallback("vesc","errorflags",self.errorCb,self.axis,int)
+        self.registerCallback("vesc","encrate",self.label_encoder_rate.setText,self.axis,str)
+        self.registerCallback("vesc","voltage",self.label_voltage.setText,self.axis,str)
+        self.registerCallback("vesc","pos",self.posCb,self.axis,int)
+        self.registerCallback("vesc","vescstate",self.stateCb,self.axis,int)
+        self.registerCallback("vesc","torque",self.stateCb,self.axis,int)
+        
+        self.initUi()
 
     def vescstate(self,i):
         _result = "Invalid state"
@@ -69,10 +83,7 @@ class VescUI(WidgetUI):
 
 
     def initUi(self):
-        self.main.comms.serialGetAsync("vescCanId?",self.spinBox_id.setValue,int,self.prefix)
-        self.main.comms.serialGetAsync("vescCanSpd?",self.updateCanSpd,int,self.prefix)
-        self.main.comms.serialGetAsync("vescUseEncoder?",self.updateEncoderUI,int)
-        self.main.comms.serialGetAsync("vescOffset?",self.updateOffset,int)
+        self.sendCommands("vesc",["canid","canspd","useencoder","offset"],self.prefix)
     
     def updateOffset(self, preset):
         self.doubleSpinBox_encoderOffset.setValue(preset / 10000)
@@ -80,31 +91,12 @@ class VescUI(WidgetUI):
     def updateCanSpd(self,preset):
         self.comboBox_baud.setCurrentIndex(preset-3) # 3 is lowest preset!
 
-    def statusUpdateCb(self,dat):
-        
-        vesc_state_label = self.vescstate(dat[0])
+    def stateCb(self,state):
+        self.label_state.setText(self.vescstate(state))
 
-        if dat[0] == 0:
-            remote_state = "-"
-        elif dat[1] == 0:
-            remote_state = "ok"
-        else:
-            remote_state = "Error code " + str(dat[1]) + ", (use vesctool)" 
-
-        vesc_encoder_rate = dat[2]
-        vesc_encoder_position = ( 360 * dat[3] ) / 1000000000
-        vesc_torque = math.ceil(dat[4] / 100)
-        vesc_voltage = dat[5] / 100
-
-        self.label_state.setText(vesc_state_label)
-        self.label_errors.setText(remote_state)
-        self.label_encoder_rate.setText(str(vesc_encoder_rate))
-        self.label_pos.setText("{:.2f}".format(vesc_encoder_position))
+    def torqueCb(self,v):
+        vesc_torque = math.ceil(v / 100)
         self.label_torque.setText(str(vesc_torque)) # not divide by 10000 but by 100 to display it in %
-        self.label_voltage.setText(str(vesc_voltage))
-
-        self.horizontalSlider_pos.setValue(vesc_encoder_position)
-
         if vesc_torque >= 0:
             self.progressBar_torqueneg.setValue(0)
             self.progressBar_torquepos.setValue(vesc_torque)
@@ -112,19 +104,33 @@ class VescUI(WidgetUI):
             self.progressBar_torqueneg.setValue(-vesc_torque)
             self.progressBar_torquepos.setValue(0)
 
+    def posCb(self,v):
+        vesc_encoder_position = ( 360 * v ) / 1000000000
+        self.label_pos.setText("{:.2f}".format(vesc_encoder_position))
+        self.horizontalSlider_pos.setValue(vesc_encoder_position)
+
+    def errorCb(self,dat):
+        txt = "Ok"
+        if dat != 0:
+            txt = "Error code " + str(dat[1])
+        self.label_errors.setText()
+
+
     def updateTimer(self):
-        self.main.comms.serialGetAsync(["vescState?","vescErrorFlag?","vescEncRate?","vescPos?","vescTorque?","vescVoltage?"],self.statusUpdateCb,int,self.prefix)
+        self.sendCommands("vesc",["vescstate","errorflags","voltage","pos","encrate","torque"],self.prefix)
+        #self.main.comms.serialGetAsync(["vescState?","vescErrorFlag?","vescEncRate?","vescPos?","vescTorque?","vescVoltage?"],self.statusUpdateCb,int,self.prefix)
  
     def apply(self):
         spdPreset = str(self.comboBox_baud.currentIndex()+3) # 3 is lowest preset!
         canId = str(self.spinBox_id.value())
-        self.main.comms.serialWrite(self.prefix+"."+"vescCanSpd="+spdPreset+";")
-        self.main.comms.serialWrite(self.prefix+"."+"vescCanId="+canId+";")
+        self.sendValue("vesc","canspd",spdPreset,instance=self.prefix)
+        self.sendValue("vesc","canid",canId,instance=self.prefix)
+
         self.initUi() # Update UI
     
     def manualEncPosRead(self):
-        self.main.comms.serialWrite(self.prefix+"."+"vescPosReadForce=1;")
+        self.sendCommand("vesc","forceposread",instance=self.prefix)
 
     def eraseOffset(self):
-        self.main.comms.serialWrite(self.prefix+"."+"vescOffset=0;")
+        self.sendValue("vesc","offset",0,instance=self.prefix)
         self.initUi()

--- a/vesc_ui.py
+++ b/vesc_ui.py
@@ -27,17 +27,17 @@ class VescUI(WidgetUI,CommunicationHandler):
         self.prefix = unique
 
         self.checkBox_useEncoder.stateChanged.connect(lambda val : self.sendValue("vesc","useencoder",(0 if val == 0 else 1),instance=self.prefix))
-        self.registerCallback("vesc","canid",self.spinBox_id.setValue,self.axis,int)
-        self.registerCallback("vesc","canspd",self.updateCanSpd,self.axis,int)
-        self.registerCallback("vesc","useencoder",self.updateEncoderUI,self.axis,int)
-        self.registerCallback("vesc","offset",self.updateOffset,self.axis,int)
+        self.registerCallback("vesc","canid",self.spinBox_id.setValue,self.prefix,int)
+        self.registerCallback("vesc","canspd",self.updateCanSpd,self.prefix,int)
+        self.registerCallback("vesc","useencoder",self.updateEncoderUI,self.prefix,int)
+        self.registerCallback("vesc","offset",self.updateOffset,self.prefix,int)
 
-        self.registerCallback("vesc","errorflags",self.errorCb,self.axis,int)
-        self.registerCallback("vesc","encrate",self.label_encoder_rate.setText,self.axis,str)
-        self.registerCallback("vesc","voltage",self.label_voltage.setText,self.axis,str)
-        self.registerCallback("vesc","pos",self.posCb,self.axis,int)
-        self.registerCallback("vesc","vescstate",self.stateCb,self.axis,int)
-        self.registerCallback("vesc","torque",self.stateCb,self.axis,int)
+        self.registerCallback("vesc","errorflags",self.errorCb,self.prefix,int)
+        self.registerCallback("vesc","encrate",self.label_encoder_rate.setText,self.prefix,str)
+        self.registerCallback("vesc","voltage",self.label_voltage.setText,self.prefix,str)
+        self.registerCallback("vesc","pos",self.posCb,self.prefix,int)
+        self.registerCallback("vesc","vescstate",self.stateCb,self.prefix,int)
+        self.registerCallback("vesc","torque",self.stateCb,self.prefix,int)
         
         self.initUi()
 
@@ -112,13 +112,12 @@ class VescUI(WidgetUI,CommunicationHandler):
     def errorCb(self,dat):
         txt = "Ok"
         if dat != 0:
-            txt = "Error code " + str(dat[1])
-        self.label_errors.setText()
+            txt = "Error code " + str(dat)
+        self.label_errors.setText(txt)
 
 
     def updateTimer(self):
         self.sendCommands("vesc",["vescstate","errorflags","voltage","pos","encrate","torque"],self.prefix)
-        #self.main.comms.serialGetAsync(["vescState?","vescErrorFlag?","vescEncRate?","vescPos?","vescTorque?","vescVoltage?"],self.statusUpdateCb,int,self.prefix)
  
     def apply(self):
         spdPreset = str(self.comboBox_baud.currentIndex()+3) # 3 is lowest preset!

--- a/vesc_ui.py
+++ b/vesc_ui.py
@@ -34,10 +34,10 @@ class VescUI(WidgetUI,CommunicationHandler):
 
         self.registerCallback("vesc","errorflags",self.errorCb,self.prefix,int)
         self.registerCallback("vesc","encrate",self.label_encoder_rate.setText,self.prefix,str)
-        self.registerCallback("vesc","voltage",self.label_voltage.setText,self.prefix,str)
+        self.registerCallback("vesc","voltage",lambda mv : self.label_voltage.setText(f"{mv/1000}V"),self.prefix,int)
         self.registerCallback("vesc","pos",self.posCb,self.prefix,int)
         self.registerCallback("vesc","vescstate",self.stateCb,self.prefix,int)
-        self.registerCallback("vesc","torque",self.stateCb,self.prefix,int)
+        self.registerCallback("vesc","torque",self.torqueCb,self.prefix,int)
         
         self.initUi()
 


### PR DESCRIPTION
This update supports the changes in firmware v1.5 from the following [PR](https://github.com/Ultrawipf/OpenFFBoard/pull/42).

Changes:

- Support for new command syntax
- Support for MT encoder class
- Active class list accessible from extras menu
- Permanent async callbacks and faster update speed when receiving commands
- Automatic preselection of FFBoard serial ports with highlighting
- TMC tab is disabled if tmc can't be detected
- More responsive
- Updates on value change broadcasts (for example via HID)
- ODrive connection detection