### PR TITLE
Fixing callback issue when changing mainclasses

### DIFF
--- a/.github/actions/build-pyinstaller/action.yml
+++ b/.github/actions/build-pyinstaller/action.yml
@@ -2,8 +2,8 @@ name: Build Configurator
 
 inputs:
   python-version:
-    description: 'Python version. 3.9 default'
-    default: '3.9'
+    description: 'Python version. 3.11 default'
+    default: '3.11'
   path: 
     description: 'input path'
     required: true
@@ -17,7 +17,7 @@ runs:
 
   # Steps represent a sequence of tasks that will be executed as part of the job
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        conf:  [ {os: 'windows-latest', pyver: '3.8'},{os: 'windows-latest', pyver: '3.9'}, {os: 'macos-latest', pyver: '3.9'}]
+        conf:  [ {os: 'windows-latest', pyver: '3.8'},{os: 'windows-latest', pyver: '3.11'}, {os: 'macos-latest', pyver: '3.10'}]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: build
         uses: ./.github/actions/build-pyinstaller
@@ -37,7 +37,7 @@ jobs:
           path: '${{ github.workspace }}'
           python-version: '${{ matrix.conf.pyver }}'
         
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: OpenFFBoard-Configurator-${{ matrix.conf.os }}-py${{ matrix.conf.pyver }}
           path: ${{ steps.build.outputs.distpath }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     # Checkout  
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Download artifacts for release
       - uses: actions/download-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Changes this version:
+- Changed units for flux offset to A
+
 ### Changes since v1.9.x:
 - Support for local encoder index
 - Fixed range slider not snapping and updating value correctly when dragged by mouse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changes this version:
 - Changed units for flux offset to A
+- Properly delete ffb rate connections when changing mainclass
 
 ### Changes since v1.9.x:
 - Support for local encoder index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Changes since v1.9.7:
+### Changes since v1.9.x:
 - Support for local encoder index
 - Fixed range slider not snapping and updating value correctly when dragged by mouse
 - Added logger function

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ import effects_graph_ui
 import updater
 
 # This GUIs version
-VERSION = "1.10.0"
+VERSION = "1.10.1"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal

--- a/res/tmc4671_ui.ui
+++ b/res/tmc4671_ui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>716</width>
+    <width>691</width>
     <height>857</height>
    </rect>
   </property>
@@ -157,24 +157,14 @@
          <item row="2" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
-            <string>Max field weakening</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="spinBox_fluxoffset">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>10000</number>
+            <string>Flux field weakening</string>
            </property>
           </widget>
          </item>
          <item row="3" column="0" colspan="2">
           <widget class="QLabel" name="label_10">
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Can increase max speed on steppers.&lt;br/&gt;Caution. Reasonable values are ~500-2000&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Can increase max speed. Caution!&lt;br/&gt;Reasonable values are ~0-1.5A&lt;br/&gt;For steppers and BLDC&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -321,6 +311,25 @@
            </property>
            <property name="value">
             <number>1000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_fluxoffset">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string>A</string>
+           </property>
+           <property name="maximum">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
            </property>
           </widget>
          </item>
@@ -588,7 +597,7 @@
            </attribute>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="0">
           <widget class="QCheckBox" name="checkBox_I_Precision">
            <property name="enabled">
             <bool>false</bool>


### PR DESCRIPTION
Fixes a problem that the "hidrate" command is still being sent after changing a mainclass and reconnecting even if the ffb class is not active by storing connections and deleting them later.

Changes the flux offset unit in the tmc tab from raw values to A for usability.