### PR TITLE
PWM Direction toggle & serial comms fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Changes this version:
 - Added PWM direction checkbox
+- When a command callback target causes an error it will remove the callback, print a warning and resume instead of aborting.
+  - Prevents issues in case a request is sent during a timeout causing empty encoder config fields in rare cases
 
 ### Changes in 1.13.x:
 - Fixed issue in encoder tuning UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Changes this version:
+- Added PWM direction checkbox
+
+### Changes in 1.13.x:
 - Fixed issue in encoder tuning UI
 - Added SSI encoder ui
 

--- a/encoderconf_ui.py
+++ b/encoderconf_ui.py
@@ -145,7 +145,7 @@ class BissEncoderConf(EncoderOption,CommunicationHandler):
         layout.setContentsMargins(0,0,0,0)
 
         self.spinBox_cs = QSpinBox()
-        self.spinBox_cs.setRange(1,3)   
+        self.spinBox_cs.setRange(1,3)
         self.spinBox_bits = QSpinBox()
         self.spinBox_bits.setRange(1,32)
         layout.addWidget(QLabel("SPI3 extension port"))
@@ -172,7 +172,7 @@ class SsiEncoderConf(EncoderOption,CommunicationHandler):
         layout.setContentsMargins(0,0,0,0)
 
         self.spinBox_cs = QSpinBox()
-        self.spinBox_cs.setRange(1,3)   
+        self.spinBox_cs.setRange(1,3)
         self.spinBox_bits = QSpinBox()
         self.spinBox_bits.setRange(1,32)
         self.comboBox_mode = QComboBox()

--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.Communicatio
         self.serial_timer = None
 
         self.systray : SystrayWrapper = None
+        
 
         self.tab_connections = [] # Signals to disconnect on reset
 
@@ -122,10 +123,10 @@ class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.Communicatio
         self.profile_ui = profile_ui.ProfileUI(main=self)
         self.serialchooser.connected.connect(self.profile_ui.setEnabled)
 
-        self.serialchooser.connected.connect(self.effects_monitor_dlg.setEnabled)
+        #self.serialchooser.connected.connect(self.effects_monitor_dlg.setEnabled) # Gets enabled in class management
         self.effects_monitor_dlg.setEnabled(False)
 
-        self.serialchooser.connected.connect(self.effects_graph_dlg.setEnabled)
+        #self.serialchooser.connected.connect(self.effects_graph_dlg.setEnabled)
         self.effects_graph_dlg.setEnabled(False)
 
         # Toolbar menu items
@@ -152,10 +153,10 @@ class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.Communicatio
         self.serialchooser.connected.connect(self.actionReset_Factory_Config.setEnabled)
 
         self.actionEffectsMonitor.triggered.connect(self.effects_monitor_dlg.display)
-        self.serialchooser.connected.connect(self.actionEffectsMonitor.setEnabled)
+        #self.serialchooser.connected.connect(self.actionEffectsMonitor.setEnabled)
 
         self.actionEffects_forces.triggered.connect(self.effects_graph_dlg.display)
-        self.serialchooser.connected.connect(self.actionEffects_forces.setEnabled)
+        #self.serialchooser.connected.connect(self.actionEffects_forces.setEnabled)
 
         # Main Panel
         layout = PyQt6.QtWidgets.QVBoxLayout()
@@ -329,6 +330,11 @@ class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.Communicatio
         self.remove_callbacks()
         self.tabsinitialized.emit(False)
 
+        self.effects_monitor_dlg.setEnabled(False)
+        self.effects_graph_dlg.setEnabled(False)
+        self.actionEffectsMonitor.setEnabled(False)
+        self.actionEffects_forces.setEnabled(False)
+
         # Delete signals
         for connection in self.tab_connections:
             PyQt6.QtCore.QObject.disconnect(connection)
@@ -422,6 +428,12 @@ class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.Communicatio
                     self.active_classes[name] = classe
                     self.add_tab(classe, name_axis)
                     self.profile_ui.set_save_btn(True)
+                elif classe_active["id"] == 0xA02: # Effects manager
+                    self.effects_monitor_dlg.setEnabled(True)
+                    self.effects_graph_dlg.setEnabled(True)
+                    self.actionEffectsMonitor.setEnabled(True)
+                    self.actionEffects_forces.setEnabled(True)
+
 
 
             self.tabsinitialized.emit(True)

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ import updater
 import simplemotion_ui
 
 # This GUIs version
-VERSION = "1.13.1"
+VERSION = "1.13.2"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal

--- a/main.py
+++ b/main.py
@@ -50,11 +50,11 @@ import updater
 import simplemotion_ui
 
 # This GUIs version
-VERSION = "1.13.0"
+VERSION = "1.13.1"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal
-MIN_FW = "1.13.0"
+MIN_FW = "1.13.1"
 
 class MainUi(PyQt6.QtWidgets.QMainWindow, base_ui.WidgetUI, base_ui.CommunicationHandler):
     """Display and manage the main UI."""

--- a/pwmdriver_ui.py
+++ b/pwmdriver_ui.py
@@ -23,6 +23,7 @@ class PwmDriverUI(WidgetUI,CommunicationHandler):
 
         self.register_callback("pwmdrv","mode",self.pwmmode_cb,0,str,typechar='!')
         self.register_callback("pwmdrv","mode",self.comboBox_mode.setCurrentIndex,0,int,typechar='?')
+        self.register_callback("pwmdrv","dir",self.checkBox_invert.setChecked,0,int,typechar='?')
 
         self.init_ui()
 
@@ -30,6 +31,7 @@ class PwmDriverUI(WidgetUI,CommunicationHandler):
         # Fill menus
         self.send_command("pwmdrv","freq",0,'!')
         self.send_command("pwmdrv","mode",0,'!')
+        self.send_command("pwmdrv","dir",0,'?')
     
     def freq_cb(self,modes):
         self.comboBox_freq.clear()
@@ -49,5 +51,6 @@ class PwmDriverUI(WidgetUI,CommunicationHandler):
     def apply(self):
         self.send_value("pwmdrv","mode",self.comboBox_mode.currentData())
         self.send_value("pwmdrv","freq",self.comboBox_freq.currentData())
+        self.send_value("pwmdrv","dir",1 if self.checkBox_invert.isChecked() else 0)
         self.init_ui() # Update UI
 

--- a/res/pwmdriver_ui.ui
+++ b/res/pwmdriver_ui.ui
@@ -30,20 +30,34 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBox_mode"/>
       </item>
-      <item row="1" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Frequency Preset:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="comboBox_freq"/>
       </item>
-      <item row="2" column="0">
+      <item row="5" column="0">
        <widget class="QPushButton" name="pushButton_apply">
         <property name="text">
          <string>Apply</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="checkBox_invert">
+        <property name="text">
+         <string>Invert direction</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Other settings:</string>
         </property>
        </widget>
       </item>

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -198,7 +198,13 @@ class SerialComms(QObject):
                     continue
                 if(callbackObject["convert"]):
                     reply = callbackObject["convert"](reply)
-                callbackObject["callback"](reply) 
+                try:
+                    callbackObject["callback"](reply)
+                    
+                except RuntimeError as e:
+                    self.logger.error("Error calling object: " + str(e))
+                    callbackObject["delete"] = True # force delete
+
                 if callbackObject["delete"]: # delete if flag is set
                     #print("Deleting",callbackObject)
                     SerialComms.callbackDict[cls].remove(callbackObject)


### PR DESCRIPTION
- Adds a direction toggle function for PWM drivers.

- When a command callback target causes an error it will remove the callback, print a warning and resume instead of aborting.
  - Prevents issues in case a request is sent during a timeout causing empty encoder config fields in rare cases