### PR TITLE
Add percentage in the power slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ### Changes this version:
-- Added PWM direction checkbox
-- When a command callback target causes an error it will remove the callback, print a warning and resume instead of aborting.
-  - Prevents issues in case a request is sent during a timeout causing empty encoder config fields in rare cases
+- Added percentage to power slider
 
 ### Changes in 1.13.x:
 - Fixed issue in encoder tuning UI
 - Added SSI encoder ui
+- Added PWM direction checkbox
+- When a command callback target causes an error it will remove the callback, print a warning and resume instead of aborting.
+  - Prevents issues in case a request is sent during a timeout causing empty encoder config fields in rare cases
+
 

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -21,6 +21,7 @@ class AxisUI(WidgetUI,CommunicationHandler):
 
         self.main = main
         self.adc_to_amps = 0.0
+        self.max_power = 0
 
         self.driver_classes = {}
         self.driver_ids = []
@@ -141,7 +142,7 @@ class AxisUI(WidgetUI,CommunicationHandler):
             self.updatePowerLabel(self.horizontalSlider_power.value())
 
     def updatePowerLabel(self,val):
-        text = str(val)
+        text = "{}\n({:.0%})".format(str(val), (val / self.max_power))
         # If tmc is used show a current estimate
         if((self.driver_id == 1 or self.driver_id == 2) and self.adc_to_amps != 0):
             current = (val * self.adc_to_amps)
@@ -217,10 +218,12 @@ class AxisUI(WidgetUI,CommunicationHandler):
     
     def updateSliders(self):
         if(self.driver_id == 1 or self.driver_id == 2): # Reduce max range for TMC (ADC saturation margin. Recommended to keep <25000)
-            self.horizontalSlider_power.setMaximum(28000)
+            self.max_power = 28000
+            self.horizontalSlider_power.setMaximum(self.max_power)
             self.get_value_async("tmc","iScale",self.setCurrentScaler,self.driver_id - 1,float)  
         else:
-            self.horizontalSlider_power.setMaximum(0x7fff)
+            self.max_power = 0x7fff
+            self.horizontalSlider_power.setMaximum(self.max_power)
 
         commands = ["power","degrees","fxratio","esgain","idlespring","axisdamper"] # requests updates
         self.send_commands("axis",commands,self.axis)

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -142,11 +142,14 @@ class AxisUI(WidgetUI,CommunicationHandler):
             self.updatePowerLabel(self.horizontalSlider_power.value())
 
     def updatePowerLabel(self,val):
-        text = "{}\n({:.0%})".format(str(val), (val / self.max_power))
+        text = str(val)
         # If tmc is used show a current estimate
         if((self.driver_id == 1 or self.driver_id == 2) and self.adc_to_amps != 0):
             current = (val * self.adc_to_amps)
             text += " ("+str(round(current,1)) + "A)"
+
+        text += "\n({:.0%})".format((val / self.max_power))
+
         self.label_power.setText(text)
 
     # Effect/Endstop ratio scaler

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ import updater
 import simplemotion_ui
 
 # This GUIs version
-VERSION = "1.13.2"
+VERSION = "1.13.3"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal

--- a/res/axis_ui.ui
+++ b/res/axis_ui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1008</width>
-    <height>551</height>
+    <width>825</width>
+    <height>522</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/res/axis_ui.ui
+++ b/res/axis_ui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>825</width>
-    <height>522</height>
+    <width>1008</width>
+    <height>551</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -592,7 +592,8 @@
          </size>
         </property>
         <property name="text">
-         <string>0</string>
+         <string>0
+(0%)</string>
         </property>
        </widget>
       </item>
@@ -622,7 +623,7 @@
       <item row="0" column="1">
        <widget class="QSlider" name="horizontalSlider_power">
         <property name="maximum">
-         <number>30000</number>
+         <number>32767</number>
         </property>
         <property name="pageStep">
          <number>100</number>


### PR DESCRIPTION
This is to give more visibility to people while using Power Slider.

Now it will show similar to:
```
32767
(100%)
```
![image](https://user-images.githubusercontent.com/3937889/234380273-cf0ac9c7-c9d7-4997-892d-28647e016132.png)


Requested at: https://discord.com/channels/704355326291607614/716259355011448883/1082151083259986052 