### PR TITLE
Updated conversion scripts to accept filename arguments and infer language from filename

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -7,7 +7,7 @@
 
    or 
 
-   b. convert into ods for google sheets, run`./translations/tool_ts_to_ods.py`(you need modify the filename inside py script) for later translation in google sheets, after translated in google sheets, run `./translations/tool_ods_to_ts.py`(you need modify the filename inside py script) to convert back.
+   b. convert into ods for google sheets, run`./translations/tool_ts_to_ods.py zh_CN.ts`(you need to provide the filename as a command line argument) for later translation in google sheets. After translating in google sheets, run `./translations/tool_ods_to_ts.py zh_CN.ods`(you need to provide the filename as a command line argument) to convert back. You will need pyexcel_ods installed (run `pip install pyexcel_ods`)
 
 3. After ts file is translated, run `lrelease ./translations/zh_CN.ts` : ts to qm
 4. python will load qm file automatically at startup or manually with `QTranslator.load()`.

--- a/translations/tool_ods_to_ts.py
+++ b/translations/tool_ods_to_ts.py
@@ -1,9 +1,25 @@
+'''
+Please install:
+pip install pyexcel_ods
+and provide file path as a command line argument of the ts file you want to convert.
+Filename should be <locale>.ods (example 'zh_CN.ods')
+'''
+
 import xml.etree.ElementTree as ET
 import pyexcel_ods
 from io import BytesIO
+import sys
 
-# Specify the path to your ODS file
-ods_file = "zh_CN.ods"
+#Check if argument is provided and take is as a file name or throw an error and exit
+if len(sys.argv) > 1:
+    ods_file = sys.argv[1]
+    print(f"Converting {ods_file}")
+else:
+    print('Error: No file name provided. Please provide a file as a command line argument.')
+    exit(1)
+
+#Set language to file name
+lang = ods_file[-9:-4]
 
 # Load the ODS file using pyexcel-ods
 ods_data = pyexcel_ods.get_data(ods_file)
@@ -12,7 +28,7 @@ data = ods_data["Sheet 1"]
 # Create an ElementTree for the .ts structure
 root = ET.Element("TS")
 root.set("version", "2.1")
-root.set("language", "zh_CN")
+root.set("language", lang)
 root.set("sourcelanguage", "en_US")
 
 current_context = None

--- a/translations/tool_ts_to_ods.py
+++ b/translations/tool_ts_to_ods.py
@@ -1,13 +1,21 @@
 '''
 Please install:
 pip install pyexcel_ods
-and change the ts_file variable to the path of the ts file you want to convert.
+and provide file path as a command line argument of the ts file you want to convert.
 '''
-ts_file = "zh_CN.ts"
 
 import xml.etree.ElementTree as ET
 import pyexcel_ods
 from io import BytesIO
+import sys
+
+#Check if argument is provided and take is as a file name or throw an error and exit
+if len(sys.argv) > 1:
+    ts_file = sys.argv[1]
+    print(f"Converting {ts_file}")
+else:
+    print('Error: No file name provided. Please provide a file as a command line argument.')
+    exit(1)
 
 # Load the .ts file using ElementTree
 tree = ET.parse(ts_file)


### PR DESCRIPTION
Now scripts to convert TS to ODS and ODS to TS accept command line arguments with file name
Language of converted TS file is now taken from file name (and not hardcoded to zh_CN)
Updated readme to account changes