### PR TITLE
fix for spinboxes bug in pyqt6 == 6.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/*
 .vscode/*
 .qt_for_python/*
 profiles.json*
+/.venv

--- a/axis_ui.py
+++ b/axis_ui.py
@@ -174,7 +174,7 @@ class AxisUI(WidgetUI,CommunicationHandler):
             self.send_command("axis","pos",self.axis)
         else:
             # cpr invalid. Request cpr
-            self.send_command("axis","cpr",typechar='?')
+            self.send_command("axis","cpr",typechar='?',instance=self.axis)
         
     
     def setCurrentScaler(self,x):

--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ import simplemotion_ui
 import activetasks
 
 # This GUIs version
-VERSION = "1.14.3"
+VERSION = "1.14.4"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal

--- a/res/axis_ui.ui
+++ b/res/axis_ui.ui
@@ -306,6 +306,12 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="minimum">
                <number>1</number>
               </property>
@@ -334,6 +340,12 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
               </property>
               <property name="minimum">
                <number>1</number>
@@ -556,6 +568,12 @@
       </item>
       <item row="0" column="2">
        <widget class="QSpinBox" name="spinBox_range">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -575,6 +593,12 @@
       </item>
       <item row="2" column="2">
        <widget class="QSpinBox" name="spinBox_damper">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -585,6 +609,12 @@
       </item>
       <item row="1" column="2">
        <widget class="QSpinBox" name="spinBox_idlespring">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -725,6 +755,12 @@
       </item>
       <item row="2" column="2">
        <widget class="QSpinBox" name="spinBox_esgain">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>

--- a/res/ffbclass.ui
+++ b/res/ffbclass.ui
@@ -215,6 +215,12 @@
       </item>
       <item row="3" column="2">
        <widget class="QDoubleSpinBox" name="doubleSpinBox_friction">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -290,6 +296,12 @@
       </item>
       <item row="4" column="2">
        <widget class="QDoubleSpinBox" name="doubleSpinBox_inertia">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -303,6 +315,12 @@
       </item>
       <item row="1" column="2">
        <widget class="QDoubleSpinBox" name="doubleSpinBox_spring">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -400,6 +418,12 @@
       </item>
       <item row="2" column="2">
        <widget class="QDoubleSpinBox" name="doubleSpinBox_damper">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -476,6 +500,12 @@
       </item>
       <item row="1" column="4">
        <widget class="QDoubleSpinBox" name="doubleSpinBox_CFq">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>

--- a/res/tmc4671_ui.ui
+++ b/res/tmc4671_ui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>707</width>
+    <width>744</width>
     <height>731</height>
    </rect>
   </property>
@@ -159,6 +159,12 @@
          </item>
          <item row="0" column="1">
           <widget class="QSpinBox" name="spinBox_tp">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="keyboardTracking">
             <bool>false</bool>
            </property>
@@ -176,6 +182,12 @@
          </item>
          <item row="1" column="1">
           <widget class="QSpinBox" name="spinBox_ti">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="keyboardTracking">
             <bool>false</bool>
            </property>
@@ -193,6 +205,12 @@
          </item>
          <item row="2" column="1">
           <widget class="QSpinBox" name="spinBox_fp">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="keyboardTracking">
             <bool>false</bool>
            </property>
@@ -210,6 +228,12 @@
          </item>
          <item row="3" column="1">
           <widget class="QSpinBox" name="spinBox_fi">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="keyboardTracking">
             <bool>false</bool>
            </property>
@@ -470,6 +494,12 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="suffix">
             <string> Hz</string>
            </property>
@@ -498,6 +528,12 @@
           <widget class="QDoubleSpinBox" name="doubleSpinBox_fluxoffset">
            <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
            </property>
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Caution: can increase max speed but can also cause steppers to accelerate exponentially if too high&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/serial_comms.py
+++ b/serial_comms.py
@@ -122,7 +122,7 @@ class SerialComms(QObject):
 
         ## send buffer commands to the board if the port is opened
         cmd_not_sent = []
-        self.logger.debug(F"Send %d lines to uart, commm is %d", len(self.send_buffer), self.serial.isOpen())
+        self.logger.debug(F"Send %d lines to uart, commm is %d %s", len(self.send_buffer), self.serial.isOpen(),self.send_buffer)
         for cmdraw in self.send_buffer:
             if self.serial.isOpen():
                 # if command can't be send, we reput them in the buffer for a retry

--- a/tmc4671_ui.py
+++ b/tmc4671_ui.py
@@ -214,7 +214,8 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         else:
             self.checkBox_svpwm.setEnabled(False)
 
-    def extEncoderChanged(self,val):
+    def extEncoderChanged(self,idx):
+        val = self.comboBox_mtype.currentData()
         self.checkBox_invertForce.setEnabled(val)
         if not val:
             self.checkBox_invertForce.setChecked(False)
@@ -339,7 +340,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
         self.send_commands("sys",["vint","vext"])
 
     def submitMotor(self):
-        mtype = self.comboBox_mtype.currentIndex()
+        mtype = self.comboBox_mtype.currentData()
         self.send_value("tmc","mtype",val=mtype,instance=self.axis)
 
         poles = self.spinBox_poles.value()
@@ -347,7 +348,7 @@ class TMC4671Ui(WidgetUI,CommunicationHandler):
 
         self.send_value("tmc","cpr",val=self.spinBox_cpr.value(),instance=self.axis)
 
-        enc = self.comboBox_enc.currentIndex()
+        enc = self.comboBox_enc.currentData()
         self.send_value("tmc","encsrc",val=enc,instance=self.axis)
 
         self.send_value("tmc","abnindex",val = 1 if self.checkBox_abnIndex.isChecked() else 0,instance=self.axis)


### PR DESCRIPTION
increase spinbox minimal width to 100 for now.
the problem is caused by the new style in pyqt6 == 6.7 have wider right side button in spinbox.