### PR TITLE
Enhance MainUI initialization and UI behavior

### DIFF
--- a/base_ui.py
+++ b/base_ui.py
@@ -47,6 +47,7 @@ class WidgetUI(PyQt6.QtWidgets.QWidget):
         self.tech_log = logging.getLogger(ui_form)
         if ui_form:
             PyQt6.uic.loadUi(helper.res_path(ui_form), self)
+            # print(f"UI file loaded : {ui_form}")
 
     def init_ui(self):
         """Prototype of init_ui to manage this status in subclass."""

--- a/profile_ui.py
+++ b/profile_ui.py
@@ -35,10 +35,30 @@ class ProfileUI(base_ui.WidgetUI, base_ui.CommunicationHandler):
     profile_selected_event = PyQt6.QtCore.pyqtSignal(str)
 
     def __init__(self, main=None):
-        """Init the UI and link the event."""
-        base_ui.WidgetUI.__init__(self, main, "profile.ui")
-        base_ui.CommunicationHandler.__init__(self)
+        """Initialize profile without UI."""
         self.main = main
+        self.profiles_dlg = None  # ProfilesDialog is not initialized yet
+        self.profile_setup = {}
+        self.profiles = {}
+
+        self._current_class = -1
+        self._current_command = -1
+        self._current_instance = -1
+        self._map_class_running = []
+        self._running_profile = []
+        self._profilename_tosave: str = None
+
+        self.ui_initialized = False
+
+        # 加载配置文件和资料
+        self.load_profile_settings()
+        self.load_profiles()
+
+    def initialize_ui(self):
+        """Init the UI and link the event."""
+        base_ui.WidgetUI.__init__(self, self.main, "profile.ui")
+        base_ui.CommunicationHandler.__init__(self)
+        
         self.profiles_dlg = ProfilesDialog(self)
         self.profiles_dlg.closeSignal.connect(self.close_profile_manager)
 
@@ -63,19 +83,7 @@ class ProfileUI(base_ui.WidgetUI, base_ui.CommunicationHandler):
             self.main.systray.refresh_profile_action_status
         )
 
-        self.profile_setup = {}
-        self.profiles = {}
-
-        self._current_class = -1
-        self._current_command = -1
-        self._current_instance = -1
-        self._map_class_running = []
-        self._running_profile = []
-        self._profilename_tosave: str = None
-
         self.setEnabled(False)
-        self.load_profile_settings()
-        self.load_profiles()
 
     def save_clicked(self):
         """Save current seeting in Flash and replace the 'Flash profile' settings by the new one."""
@@ -141,7 +149,9 @@ class ProfileUI(base_ui.WidgetUI, base_ui.CommunicationHandler):
             self.log("Profile: profiles are not compatible, need to redo them")
         else:
             self.log("Profile: profiles loaded")
-        self.refresh_combox_list()
+        
+        if self.ui_initialized:
+            self.refresh_combox_list()
 
     def create_or_update_profile_file(self, create: bool = False):
         """Create a profile file if not exist, else update the existing one."""

--- a/updater.py
+++ b/updater.py
@@ -48,7 +48,7 @@ class GithubRelease():
         """Returns the latest release for repo or empty dict on error"""
         url = f"https://api.github.com/repos/{repo}/releases/latest"
         try:
-            response = requests.get(url)
+            response = requests.get(url,timeout=3) # timeout to avoid blocking when board connecting
         except requests.ConnectionError:
             return {}
         if not response:


### PR DESCRIPTION
- Implemented a new profile initialization without UI and adjusted the initialization order within MainUI.
- Prevented dark mode changes when using the "Windows 11" style (this style is compatible with dark mode).
- Added a 3-second timeout when checking github.com to avoid blocking during board connections.

Known issue: After booting, changing the language from any translation to en_US requires a manual restart of the application to take effect.

https://github.com/Ultrawipf/OpenFFBoard-configurator/issues/85