### PR TITLE
Bugfix v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Changes this version:
+- Fixed shifter threshold range to allow increased ranges in v1.16 firmware
+
+### Changes in v16.x:
 - Added RMD CAN motor tab
 - Chip temperature status added
 - Save button is disabled during saving to prevent multiple clicks

--- a/buttonconf_ui.py
+++ b/buttonconf_ui.py
@@ -233,7 +233,7 @@ class ShifterButtonsConf(OptionsDialogGroupBox,CommunicationHandler):
             vbox.addWidget(QLabel(name))
             numBtnBox = QSpinBox()
             numBtnBox.setMinimum(0)
-            numBtnBox.setMaximum(4096)
+            numBtnBox.setMaximum(0xffff)
             vbox.addWidget(numBtnBox)
             return numBtnBox
 

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ import activetasks
 import rmd_ui
 
 # This GUIs version
-VERSION = "1.16.0"
+VERSION = "1.16.1"
 
 # Minimal supported firmware version.
 # Major version of firmware must match firmware. Minor versions must be higher or equal


### PR DESCRIPTION
Fixes the shifter popup clipping thresholds to a low value.

The internal scaling has been unified to 16b so the thresholds need to be adjusted to allow the higher range.