### PR TITLE
Fix crash when $XDG_CONFIG_HOME/openffb doesn't exist

### DIFF
--- a/profile_ui.py
+++ b/profile_ui.py
@@ -188,7 +188,7 @@ class ProfileUI(base_ui.WidgetUI, base_ui.CommunicationHandler):
             self.log("Profile: profile file created")
 
             # Ensure the parent directory exists
-            os.makedirs(get_config_dir_path(), exist_ok=True)
+            os.makedirs(get_config_dir_path(self.__PROFILES_FILENAME), exist_ok=True)
 
         try:
             with open(self.__PROFILES_FILEPATH, "w", encoding="utf_8") as f:


### PR DESCRIPTION
Late change to #96 resulted in this line being accidentally left out which will cause the program to crash for users who don't have this directory already initialised. This PR fixes it by passing the required argument.